### PR TITLE
kv/LevelDBStore, FileStore, MonDBStore: simpler code for single-key fetches

### DIFF
--- a/src/kv/LevelDBStore.cc
+++ b/src/kv/LevelDBStore.cc
@@ -218,6 +218,25 @@ int LevelDBStore::get(
   return 0;
 }
 
+int LevelDBStore::get(const string &prefix, 
+		  const string &key,
+		  bufferlist *value)
+{
+  utime_t start = ceph_clock_now(g_ceph_context);
+  int r = 0;
+  KeyValueDB::Iterator it = get_iterator(prefix);
+  it->lower_bound(key);
+  if (it->valid() && it->key() == key) {
+    *value = it->value();
+  } else {
+    r = -ENOENT;
+  }
+  utime_t lat = ceph_clock_now(g_ceph_context) - start;
+  logger->inc(l_leveldb_gets);
+  logger->tinc(l_leveldb_get_latency, lat);
+  return r;
+}
+
 string LevelDBStore::combine_strings(const string &prefix, const string &value)
 {
   string out = prefix;

--- a/src/kv/LevelDBStore.h
+++ b/src/kv/LevelDBStore.h
@@ -205,6 +205,10 @@ public:
     std::map<string, bufferlist> *out
     );
 
+  int get(const string &prefix, 
+    const string &key,   
+    bufferlist *value);
+      
   class LevelDBWholeSpaceIteratorImpl :
     public KeyValueDB::WholeSpaceIteratorImpl {
   protected:

--- a/src/mon/MonitorDBStore.h
+++ b/src/mon/MonitorDBStore.h
@@ -507,14 +507,12 @@ class MonitorDBStore
   }
 
   int get(const string& prefix, const string& key, bufferlist& bl) {
-    set<string> k;
-    k.insert(key);
-    map<string,bufferlist> out;
-
-    db->get(prefix, k, &out);
-    if (out.empty())
+    
+    bufferlist outbl;
+    db->get(prefix, key, &outbl);
+    if (outbl.length() == 0) 
       return -ENOENT;
-    bl.append(out[key]);
+    bl.append(outbl);
 
     return 0;
   }

--- a/src/os/DBObjectMap.cc
+++ b/src/os/DBObjectMap.cc
@@ -1089,17 +1089,16 @@ DBObjectMap::Header DBObjectMap::_lookup_map_header(
     }
   }
 
-  map<string, bufferlist> out;
-  set<string> to_get;
-  to_get.insert(map_header_key(oid));
-  int r = db->get(HOBJECT_TO_SEQ, to_get, &out);
-  if (r < 0 || out.empty()) {
+  bufferlist out;
+  int r = db->get(HOBJECT_TO_SEQ, map_header_key(oid), &out);
+  if (r < 0 || out.length()==0) {
     delete header;
     return Header();
   }
 
   Header ret(header, RemoveOnDelete(this));
-  bufferlist::iterator iter = out.begin()->second.begin();
+  bufferlist::iterator iter = out.begin();
+
   ret->decode(iter);
   {
     Mutex::Locker l(cache_lock);


### PR DESCRIPTION
Often there's a need to fetch value for a specified, single key. Publish
a new method in LevelDB that takes key and prefix and puts just value at
specified address, without the need for interim keysets or resultsets.
Make use of that method in MonitorDBStore and LevelDB (not all cases, only
the most often called ones).

Signed-off-by: Piotr Dałek piotr.dalek@ts.fujitsu.com
