### PR TITLE
os/osd: disable extra iterator validation

### DIFF
--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -141,7 +141,7 @@ public:
     virtual int upper_bound(const std::string &after) = 0;
     virtual int lower_bound(const std::string &to) = 0;
     virtual bool valid() = 0;
-    virtual int next() = 0;
+    virtual int next(bool validate=true) = 0;
     virtual std::string key() = 0;
     virtual bufferlist value() = 0;
     virtual int status() = 0;
@@ -193,15 +193,26 @@ public:
 	return false;
       return generic_iter->raw_key_is_prefixed(prefix);
     }
-    int next() {
-      if (valid())
-	return generic_iter->next();
-      return status();
+    // Note that next() and prev() shouldn't validate iters,
+    // it's responsibility of caller to ensure they're valid.
+    int next(bool validate=true) {
+      if (validate) {
+        if (valid())
+          return generic_iter->next();
+        return status();
+      } else {
+        return generic_iter->next();  
+      }      
     }
-    int prev() {
-      if (valid())
-	return generic_iter->prev();
-      return status();
+    
+    int prev(bool validate=true) {
+      if (validate) {
+        if (valid())
+          return generic_iter->prev();
+        return status();
+      } else {
+        return generic_iter->prev();  
+      }      
     }
     std::string key() {
       return generic_iter->key();

--- a/src/os/DBObjectMap.cc
+++ b/src/os/DBObjectMap.cc
@@ -344,7 +344,7 @@ bool DBObjectMap::DBObjectMapIteratorImpl::valid_parent()
   return false;
 }
 
-int DBObjectMap::DBObjectMapIteratorImpl::next()
+int DBObjectMap::DBObjectMapIteratorImpl::next(bool validate)
 {
   assert(cur_iter->valid());
   assert(valid());

--- a/src/os/DBObjectMap.h
+++ b/src/os/DBObjectMap.h
@@ -347,7 +347,7 @@ private:
     int upper_bound(const string &after) { return 0; }
     int lower_bound(const string &to) { return 0; }
     bool valid() { return false; }
-    int next() { assert(0); return 0; }
+    int next(bool validate=true) { assert(0); return 0; }
     string key() { assert(0); return ""; }
     bufferlist value() { assert(0); return bufferlist(); }
     int status() { return 0; }
@@ -385,7 +385,7 @@ private:
     int upper_bound(const string &after);
     int lower_bound(const string &to);
     bool valid();
-    int next();
+    int next(bool validate=true);
     string key();
     bufferlist value();
     int status();

--- a/src/os/GenericObjectMap.cc
+++ b/src/os/GenericObjectMap.cc
@@ -415,7 +415,7 @@ bool GenericObjectMap::GenericObjectMapIteratorImpl::valid_parent()
   return false;
 }
 
-int GenericObjectMap::GenericObjectMapIteratorImpl::next()
+int GenericObjectMap::GenericObjectMapIteratorImpl::next(bool validate)
 {
   assert(cur_iter->valid());
   assert(valid());

--- a/src/os/GenericObjectMap.h
+++ b/src/os/GenericObjectMap.h
@@ -298,7 +298,7 @@ private:
     int upper_bound(const string &after) { return 0; }
     int lower_bound(const string &to) { return 0; }
     bool valid() { return false; }
-    int next() { assert(0); return 0; }
+    int next(bool validate=true) { assert(0); return 0; }
     string key() { assert(0); return ""; }
     bufferlist value() { assert(0); return bufferlist(); }
     int status() { return 0; }
@@ -337,7 +337,7 @@ private:
     int upper_bound(const string &after);
     int lower_bound(const string &to);
     bool valid();
-    int next();
+    int next(bool validate=true);
     string key();
     bufferlist value();
     int status();

--- a/src/os/KeyValueStore.cc
+++ b/src/os/KeyValueStore.cc
@@ -2729,7 +2729,7 @@ int KeyValueStore::_omap_rmkeyrange(coll_t cid, const ghobject_t &hoid,
       return -ENOENT;
 
     for (iter->lower_bound(first); iter->valid() && iter->key() < last;
-         iter->next()) {
+         iter->next(false)) {
       keys.insert(iter->key());
     }
   }

--- a/src/os/MemStore.h
+++ b/src/os/MemStore.h
@@ -271,7 +271,7 @@ private:
       std::lock_guard<std::mutex>(o->omap_mutex);
       return it != o->omap.end();      
     }
-    int next() {
+    int next(bool validate=true) {
       std::lock_guard<std::mutex>(o->omap_mutex);
       ++it;
       return 0;

--- a/src/os/newstore/NewStore.cc
+++ b/src/os/newstore/NewStore.cc
@@ -1708,7 +1708,7 @@ bool NewStore::OmapIteratorImpl::valid()
   }
 }
 
-int NewStore::OmapIteratorImpl::next()
+int NewStore::OmapIteratorImpl::next(bool validate)
 {
   RWLock::RLocker l(c->lock);
   if (o->onode.omap_head) {

--- a/src/os/newstore/NewStore.h
+++ b/src/os/newstore/NewStore.h
@@ -124,7 +124,7 @@ public:
     int upper_bound(const string &after);
     int lower_bound(const string &to);
     bool valid();
-    int next();
+    int next(bool validate=true);
     string key();
     bufferlist value();
     int status() {

--- a/src/osd/PGLog.cc
+++ b/src/osd/PGLog.cc
@@ -887,7 +887,7 @@ void PGLog::read_log(ObjectStore *store, coll_t pg_coll,
   log.rollback_info_trimmed_to = eversion_t();
   ObjectMap::ObjectMapIterator p = store->get_omap_iterator(log_coll, log_oid);
   if (p) {
-    for (p->seek_to_first(); p->valid() ; p->next()) {
+    for (p->seek_to_first(); p->valid() ; p->next(false)) {
       // non-log pgmeta_oid keys are prefixed with _; skip those
       if (p->key()[0] == '_')
 	continue;

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -813,7 +813,7 @@ void ReplicatedBackend::be_deep_scrub(
       poid, ghobject_t::NO_GEN, get_parent()->whoami_shard().shard));
   assert(iter);
   uint64_t keys_scanned = 0;
-  for (iter->seek_to_first(); iter->valid() ; iter->next()) {
+  for (iter->seek_to_first(); iter->valid() ; iter->next(false)) {
     if (cct->_conf->osd_scan_list_ping_tp_interval &&
 	(keys_scanned % cct->_conf->osd_scan_list_ping_tp_interval == 0)) {
       handle.reset_tp_timeout();
@@ -2034,7 +2034,7 @@ int ReplicatedBackend::build_push_op(const ObjectRecoveryInfo &recovery_info,
 			       ghobject_t(recovery_info.soid));
     for (iter->lower_bound(progress.omap_recovered_to);
 	 iter->valid();
-	 iter->next()) {
+	 iter->next(false)) {
       if (!out_op->omap_entries.empty() &&
 	  available <= (iter->key().size() + iter->value().length()))
 	break;

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -5287,7 +5287,7 @@ int ReplicatedPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	  iter->upper_bound(start_after);
 	  for (uint64_t i = 0;
 	       i < max_return && iter->valid();
-	       ++i, iter->next()) {
+	       ++i, iter->next(false)) {
 	    out_set.insert(iter->key());
 	  }
 	} // else return empty out_set
@@ -5329,7 +5329,7 @@ int ReplicatedPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	  for (uint64_t i = 0;
 	       i < max_return && iter->valid() &&
 		 iter->key().substr(0, filter_prefix.size()) == filter_prefix;
-	       ++i, iter->next()) {
+	       ++i, iter->next(false)) {
 	    dout(20) << "Found key " << iter->key() << dendl;
 	    out_set.insert(make_pair(iter->key(), iter->value()));
 	  }
@@ -6728,7 +6728,7 @@ int ReplicatedPG::fill_in_copy_get(
 	osd->store->get_omap_iterator(coll, ghobject_t(oi.soid));
       assert(iter);
       iter->upper_bound(cursor.omap_offset);
-      for (; iter->valid(); iter->next()) {
+      for (; iter->valid(); iter->next(false)) {
 	++omap_keys;
 	::encode(iter->key(), omap_data);
 	::encode(iter->value(), omap_data);


### PR DESCRIPTION
In a number of loops using ObjectMapIterator, the iterator is validated
twice, first as an loop break condition, then during iter->next() call.
Suppress the validation in next() method in those cases for better
performance by adding possibility to not call valid() from within
next().

Signed-off-by: Piotr Dałek piotr.dalek@ts.fujitsu.com
