### PR TITLE
os/bluestore: [RFC] merge multiple TransContext into a batch to improve performance

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1123,6 +1123,7 @@ OPTION(bluestore_debug_prefragment_max, OPT_INT, 1048576)
 OPTION(bluestore_debug_inject_read_err, OPT_BOOL, false)
 OPTION(bluestore_debug_randomize_serial_transaction, OPT_INT, 0)
 OPTION(bluestore_debug_omit_block_device_write, OPT_BOOL, false)
+OPTION(bluestore_max_contexts_per_kv_batch, OPT_INT, 64)
 
 OPTION(kstore_max_ops, OPT_U64, 512)
 OPTION(kstore_max_bytes, OPT_U64, 64*1024*1024)

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1123,7 +1123,6 @@ OPTION(bluestore_debug_prefragment_max, OPT_INT, 1048576)
 OPTION(bluestore_debug_inject_read_err, OPT_BOOL, false)
 OPTION(bluestore_debug_randomize_serial_transaction, OPT_INT, 0)
 OPTION(bluestore_debug_omit_block_device_write, OPT_BOOL, false)
-OPTION(bluestore_shard_finishers, OPT_BOOL, false)
 
 OPTION(kstore_max_ops, OPT_U64, 512)
 OPTION(kstore_max_bytes, OPT_U64, 64*1024*1024)

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -58,7 +58,7 @@ extern "C" {
 #include <vector>
 #include <iostream>
 #include <iomanip>
-
+#include <boost/intrusive/list.hpp>
 using namespace std;
 
 #include "include/unordered_map.h"
@@ -107,6 +107,17 @@ inline ostream& operator<<(ostream& out, const vector<A,Alloc>& v) {
 }
 template<class A, class Alloc>
 inline ostream& operator<<(ostream& out, const deque<A,Alloc>& v) {
+  out << "<";
+  for (auto p = v.begin(); p != v.end(); ++p) {
+    if (p != v.begin()) out << ",";
+    out << *p;
+  }
+  out << ">";
+  return out;
+}
+
+template<class A, class H>
+inline ostream& operator<<(ostream& out, const boost::intrusive::list<A,H>& v) {
   out << "<";
   for (auto p = v.begin(); p != v.end(); ++p) {
     if (p != v.begin()) out << ",";

--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -21,6 +21,8 @@ using std::string;
  */
 class KeyValueDB {
 public:
+  class TransactionImpl;
+  typedef ceph::shared_ptr< TransactionImpl > Transaction;
   class TransactionImpl {
   public:
     /// Set Keys
@@ -130,9 +132,12 @@ public:
       const bufferlist  &value     ///< [in] value to be merged into key
     ) { assert(0 == "Not implemented"); }
 
+    virtual void merge_from(KeyValueDB::Transaction) {
+      assert("Not implemented");
+    }
+
     virtual ~TransactionImpl() {}
   };
-  typedef ceph::shared_ptr< TransactionImpl > Transaction;
 
   /// create a new instance
   static KeyValueDB *create(CephContext *cct, const std::string& type,

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -250,6 +250,7 @@ public:
   class RocksDBTransactionImpl : public KeyValueDB::TransactionImpl {
   public:
     rocksdb::WriteBatch bat;
+    string strBat;
     RocksDBStore *db;
 
     explicit RocksDBTransactionImpl(RocksDBStore *_db);
@@ -283,12 +284,16 @@ public:
       const string& prefix,
       const string& k,
       const bufferlist &bl) override;
+
+    void merge_from(KeyValueDB::Transaction) override;
+    void flush_batch();
   };
 
   KeyValueDB::Transaction get_transaction() override {
     return std::make_shared<RocksDBTransactionImpl>(this);
   }
 
+  int submit_transaction(const string& stransact);
   int submit_transaction(KeyValueDB::Transaction t) override;
   int submit_transaction_sync(KeyValueDB::Transaction t) override;
   int get(

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7509,20 +7509,20 @@ void BlueStore::_txc_committed_kv(TransContext *txc)
     txc->onreadable_sync->complete(0);
     txc->onreadable_sync = NULL;
   }
-  unsigned n = txc->osr->parent->shard_hint.hash_to_shard(m_finisher_num);
   if (txc->oncommit) {
     logger->tinc(l_bluestore_commit_lat, ceph_clock_now() - txc->start);
-    finishers[n]->queue(txc->oncommit);
+    txc->oncommit->complete(0);
     txc->oncommit = NULL;
   }
   if (txc->onreadable) {
-    finishers[n]->queue(txc->onreadable);
+    txc->onreadable->complete(0);
     txc->onreadable = NULL;
   }
-
-  if (!txc->oncommits.empty()) {
-    finishers[n]->queue(txc->oncommits);
+  for (auto c : txc->oncommits) {
+    c->complete(0);
   }
+  txc->oncommits.clear();
+
   throttle_ops.put(txc->ops);
   throttle_bytes.put(txc->bytes);
 }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7766,22 +7766,47 @@ void BlueStore::_kv_sync_thread()
 	t->set(PREFIX_SUPER, "blobid_max", bl);
 	dout(10) << __func__ << " new_blobid_max " << new_blobid_max << dendl;
       }
-      for (auto& txc : kv_submitting) {
-	assert(txc.state == TransContext::STATE_KV_QUEUED);
-	_txc_finalize_kv(&txc, txc.t);
-	txc.log_state_latency(logger, l_bluestore_state_kv_queued_lat);
-	int r = db->submit_transaction(txc.t);
+      auto end = kv_submitting.end();
+      int max_batch = cct->_conf->bluestore_max_contexts_per_kv_batch;
+      for (auto it = kv_submitting.begin(); it != end; ) {
+        auto iit = it;
+        auto& txc0 = *iit;
+
+	// handle txc0 out of the loop to prevent from merge_from() call
+        assert(txc0.state == TransContext::STATE_KV_QUEUED);
+        _txc_finalize_kv(&txc0, txc0.t);
+        txc0.log_state_latency(logger, l_bluestore_state_kv_queued_lat);
+        iit = it;
+        ++iit;
+
+        int pos = 1;
+	for(; pos < max_batch && iit != end; iit++ ) {
+          auto& txc = *iit;
+
+	  assert(txc.state == TransContext::STATE_KV_QUEUED);
+	  _txc_finalize_kv(&txc, txc.t);
+	  txc.log_state_latency(logger, l_bluestore_state_kv_queued_lat);
+
+	  txc0.t->merge_from(txc.t);
+          ++pos;
+        }
+	int r = db->submit_transaction(txc0.t);
 	assert(r == 0);
-	_txc_applied_kv(&txc);
-	--txc.osr->kv_committing_serially;
-	txc.state = TransContext::STATE_KV_SUBMITTED;
-	if (txc.osr->kv_submitted_waiters) {
-	  std::lock_guard<std::mutex> l(txc.osr->qlock);
-	  if (txc.osr->_is_all_kv_submitted()) {
-	    txc.osr->qcond.notify_all();
-	  }
+        for( auto iit2 = it; iit2 != iit; iit2++ ) {
+          auto& txc = *iit2;
+	  _txc_applied_kv(&txc);
+	  --txc.osr->kv_committing_serially;
+	  txc.state = TransContext::STATE_KV_SUBMITTED;
+	  if (txc.osr->kv_submitted_waiters) {
+	    std::lock_guard<std::mutex> l(txc.osr->qlock);
+	    if (txc.osr->_is_all_kv_submitted()) {
+	      txc.osr->qcond.notify_all();
+	    }
+          }
 	}
+	it = iit;
       }
+
       // Required for clean TransContext release triggered from txc_state_proc
       kv_submitting.clear(); 
       uint64_t ops = 0, bytes = 0;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3185,17 +3185,6 @@ BlueStore::BlueStore(CephContext *cct, const string& path)
   _init_logger();
   cct->_conf->add_observer(this);
   set_cache_shards(1);
-
-  if (cct->_conf->bluestore_shard_finishers) {
-    m_finisher_num = cct->_conf->osd_op_num_shards;
-  }
-
-  for (int i = 0; i < m_finisher_num; ++i) {
-    ostringstream oss;
-    oss << "finisher-" << i;
-    Finisher *f = new Finisher(cct, oss.str(), "finisher");
-    finishers.push_back(f);
-  }
 }
 
 BlueStore::BlueStore(CephContext *cct,
@@ -3219,26 +3208,10 @@ BlueStore::BlueStore(CephContext *cct,
   _init_logger();
   cct->_conf->add_observer(this);
   set_cache_shards(1);
-
-  if (cct->_conf->bluestore_shard_finishers) {
-    m_finisher_num = cct->_conf->osd_op_num_shards;
-  }
-
-  for (int i = 0; i < m_finisher_num; ++i) {
-    ostringstream oss;
-    oss << "finisher-" << i;
-    Finisher *f = new Finisher(cct, oss.str(), "finisher");
-    finishers.push_back(f);
-  }
 }
 
 BlueStore::~BlueStore()
 {
-  for (auto f : finishers) {
-    delete f;
-  }
-  finishers.clear();
-
   cct->_conf->remove_observer(this);
   _shutdown_logger();
   assert(!mounted);
@@ -4812,9 +4785,6 @@ int BlueStore::mount()
       goto out_coll;
   }
 
-  for (auto f : finishers) {
-    f->start();
-  }
   kv_sync_thread.create("bstore_kv_sync");
   kv_finalize_thread.create("bstore_kv_final");
 
@@ -4832,10 +4802,6 @@ int BlueStore::mount()
 
  out_stop:
   _kv_stop();
-  for (auto f : finishers) {
-    f->wait_for_empty();
-    f->stop();
-  }
  out_coll:
   flush_cache();
  out_alloc:
@@ -4865,12 +4831,6 @@ int BlueStore::umount()
 
   dout(20) << __func__ << " stopping kv thread" << dendl;
   _kv_stop();
-  for (auto f : finishers) {
-    dout(20) << __func__ << " draining finisher" << dendl;
-    f->wait_for_empty();
-    dout(20) << __func__ << " stopping finisher" << dendl;
-    f->stop();
-  }
   _reap_collections();
   flush_cache();
   dout(20) << __func__ << " closing" << dendl;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7522,9 +7522,6 @@ void BlueStore::_txc_committed_kv(TransContext *txc)
     c->complete(0);
   }
   txc->oncommits.clear();
-
-  throttle_ops.put(txc->ops);
-  throttle_bytes.put(txc->bytes);
 }
 
 void BlueStore::_txc_finish(TransContext *txc)
@@ -7816,11 +7813,12 @@ void BlueStore::_kv_sync_thread()
 	  }
 	}
       }
-      if (num_aios) {
-	for (auto txc : kv_committing) {
-	  if (txc->had_ios) {
-	    --txc->osr->txc_with_unstable_io;
-	  }
+      uint64_t ops = 0, bytes = 0;
+      for (auto txc : kv_committing) {
+	ops += txc->ops;
+	bytes += txc->bytes;
+	if (txc->had_ios) {
+	  --txc->osr->txc_with_unstable_io;
 	}
       }
 
@@ -7898,6 +7896,10 @@ void BlueStore::_kv_sync_thread()
 	}
 	bluefs_extents_reclaiming.clear();
       }
+
+      // release throttle now that they are committed
+      throttle_ops.put(ops);
+      throttle_bytes.put(bytes);
 
       {
 	std::unique_lock<std::mutex> m(kv_finalize_lock);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3179,6 +3179,7 @@ BlueStore::BlueStore(CephContext *cct, const string& path)
 		       cct->_conf->bluestore_max_bytes +
 		       cct->_conf->bluestore_deferred_max_bytes),
     kv_sync_thread(this),
+    kv_finalize_thread(this),
     mempool_thread(this)
 {
   _init_logger();
@@ -3210,6 +3211,7 @@ BlueStore::BlueStore(CephContext *cct,
 		       cct->_conf->bluestore_max_bytes +
 		       cct->_conf->bluestore_deferred_max_bytes),
     kv_sync_thread(this),
+    kv_finalize_thread(this),
     min_alloc_size(_min_alloc_size),
     min_alloc_size_order(ctz(_min_alloc_size)),
     mempool_thread(this)
@@ -4814,6 +4816,7 @@ int BlueStore::mount()
     f->start();
   }
   kv_sync_thread.create("bstore_kv_sync");
+  kv_finalize_thread.create("bstore_kv_final");
 
   r = _deferred_replay();
   if (r < 0)
@@ -7659,6 +7662,10 @@ void BlueStore::_osr_drain_all()
     std::lock_guard<std::mutex> l(kv_lock);
     kv_cond.notify_one();
   }
+  {
+    std::lock_guard<std::mutex> l(kv_finalize_lock);
+    kv_finalize_cond.notify_one();
+  }
   for (auto osr : s) {
     dout(20) << __func__ << " drain " << osr << dendl;
     osr->drain();
@@ -7876,11 +7883,83 @@ void BlueStore::_kv_sync_thread()
 	logger->tinc(l_bluestore_kv_commit_lat, dur_kv);
 	logger->tinc(l_bluestore_kv_lat, dur);
       }
-      while (!kv_committing.empty()) {
-	TransContext *txc = kv_committing.front();
+
+      if (bluefs) {
+	if (!bluefs_gift_extents.empty()) {
+	  _commit_bluefs_freespace(bluefs_gift_extents);
+	}
+	for (auto p = bluefs_extents_reclaiming.begin();
+	     p != bluefs_extents_reclaiming.end();
+	     ++p) {
+	  dout(20) << __func__ << " releasing old bluefs 0x" << std::hex
+		   << p.get_start() << "~" << p.get_len() << std::dec
+		   << dendl;
+	  alloc->release(p.get_start(), p.get_len());
+	}
+	bluefs_extents_reclaiming.clear();
+      }
+
+      {
+	std::unique_lock<std::mutex> m(kv_finalize_lock);
+	if (kv_committing_to_finalize.empty()) {
+	  kv_committing_to_finalize.swap(kv_committing);
+	} else {
+	  kv_committing_to_finalize.insert(
+	    kv_committing_to_finalize.end(),
+	    kv_committing.begin(),
+	    kv_committing.end());
+	  kv_committing.clear();
+	}
+	if (deferred_stable_to_finalize.empty()) {
+	  deferred_stable_to_finalize.swap(deferred_stable);
+	} else {
+	  deferred_stable_to_finalize.insert(
+	    deferred_stable_to_finalize.end(),
+	    deferred_stable.begin(),
+	    deferred_stable.end());
+          deferred_stable.clear();
+	}
+	kv_finalize_cond.notify_one();
+      }
+
+      l.lock();
+      // previously deferred "done" are now "stable" by virtue of this
+      // commit cycle.
+      deferred_stable_queue.swap(deferred_done);
+    }
+  }
+  dout(10) << __func__ << " finish" << dendl;
+}
+
+void BlueStore::_kv_finalize_thread()
+{
+  deque<TransContext*> deferred_stable, kv_committed;
+  dout(10) << __func__ << " start" << dendl;
+  std::unique_lock<std::mutex> l(kv_finalize_lock);
+  while (true) {
+    assert(kv_committed.empty());
+    assert(deferred_stable.empty());
+    if (kv_committing_to_finalize.empty() &&
+	deferred_stable_to_finalize.empty()) {
+      if (kv_stop)
+	break;
+      dout(20) << __func__ << " sleep" << dendl;
+      kv_sync_cond.notify_all();
+      kv_finalize_cond.wait(l);
+      dout(20) << __func__ << " wake" << dendl;
+    } else {
+      kv_committed.swap(kv_committing_to_finalize);
+      deferred_stable.swap(deferred_stable_to_finalize);
+      kv_finalize_cond.notify_one();
+      l.unlock();
+      dout(20) << __func__ << " kv_committed " << kv_committed << dendl;
+      dout(20) << __func__ << " deferred_stable " << deferred_stable << dendl;
+
+      while (!kv_committed.empty()) {
+	TransContext *txc = kv_committed.front();
 	assert(txc->state == TransContext::STATE_KV_SUBMITTED);
 	_txc_state_proc(txc);
-	kv_committing.pop_front();
+	kv_committed.pop_front();
       }
       while (!deferred_stable.empty()) {
 	TransContext *txc = deferred_stable.front();
@@ -7900,25 +7979,7 @@ void BlueStore::_kv_sync_thread()
       // this is as good a place as any ...
       _reap_collections();
 
-      if (bluefs) {
-	if (!bluefs_gift_extents.empty()) {
-	  _commit_bluefs_freespace(bluefs_gift_extents);
-	}
-	for (auto p = bluefs_extents_reclaiming.begin();
-	     p != bluefs_extents_reclaiming.end();
-	     ++p) {
-	  dout(20) << __func__ << " releasing old bluefs 0x" << std::hex
-		   << p.get_start() << "~" << p.get_len() << std::dec
-		   << dendl;
-	  alloc->release(p.get_start(), p.get_len());
-	}
-	bluefs_extents_reclaiming.clear();
-      }
-
       l.lock();
-      // previously deferred "done" are now "stable" by virtue of this
-      // commit cycle.
-      deferred_stable_queue.swap(deferred_done);
     }
   }
   dout(10) << __func__ << " finish" << dendl;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7209,10 +7209,10 @@ void BlueStore::_txc_state_proc(TransContext *txc)
       }
       {
 	std::lock_guard<std::mutex> l(kv_lock);
-	kv_queue.push_back(txc);
+	kv_queue.push_back(*txc);
 	kv_cond.notify_one();
 	if (txc->state != TransContext::STATE_KV_SUBMITTED) {
-	  kv_queue_unsubmitted.push_back(txc);
+	  kv_queue_unsubmitted.push_back(*txc);
 	  ++txc->osr->kv_committing_serially;
 	}
       }
@@ -7658,8 +7658,16 @@ void BlueStore::_osr_unregister_all()
   }
 }
 
+ostream& operator<<(ostream& out, const BlueStore::TransContext& tc) {
+  out << &tc;
+  return out;
+}
+
 void BlueStore::_kv_sync_thread()
 {
+  commit_queue_t kv_committing; 	  // currently syncing
+  deferred_queue_t deferred_stable_queue; // deferred ios done + stable
+
   dout(10) << __func__ << " start" << dendl;
   std::unique_lock<std::mutex> l(kv_lock);
   while (true) {
@@ -7674,8 +7682,8 @@ void BlueStore::_kv_sync_thread()
       kv_cond.wait(l);
       dout(20) << __func__ << " wake" << dendl;
     } else {
-      deque<TransContext*> kv_submitting;
-      deque<TransContext*> deferred_done, deferred_stable;
+      submit_queue_t kv_submitting;
+      deferred_queue_t deferred_done, deferred_stable;
       dout(20) << __func__ << " committing " << kv_queue.size()
 	       << " submitting " << kv_queue_unsubmitted.size()
 	       << " deferred done " << deferred_done_queue.size()
@@ -7694,8 +7702,8 @@ void BlueStore::_kv_sync_thread()
       dout(30) << __func__ << " deferred_stable " << deferred_stable << dendl;
 
       int num_aios = 0;
-      for (auto txc : kv_committing) {
-	if (txc->had_ios) {
+      for (auto& txc : kv_committing) {
+	if (txc.had_ios) {
 	  ++num_aios;
 	}
       }
@@ -7725,9 +7733,10 @@ void BlueStore::_kv_sync_thread()
 	bdev->flush();
 
 	// if we flush then deferred done are now deferred stable
-	deferred_stable.insert(deferred_stable.end(), deferred_done.begin(),
+	deferred_stable.splice(deferred_stable.end(),
+			       deferred_done,
+			       deferred_done.begin(),
 			       deferred_done.end());
-	deferred_done.clear();
       }
       utime_t after_flush = ceph_clock_now();
 
@@ -7741,7 +7750,7 @@ void BlueStore::_kv_sync_thread()
       uint64_t new_nid_max = 0, new_blobid_max = 0;
       if (nid_last + cct->_conf->bluestore_nid_prealloc/2 > nid_max) {
 	KeyValueDB::Transaction t =
-	  kv_submitting.empty() ? synct : kv_submitting.front()->t;
+	  kv_submitting.empty() ? synct : kv_submitting.front().t;
 	new_nid_max = nid_last + cct->_conf->bluestore_nid_prealloc;
 	bufferlist bl;
 	::encode(new_nid_max, bl);
@@ -7750,35 +7759,37 @@ void BlueStore::_kv_sync_thread()
       }
       if (blobid_last + cct->_conf->bluestore_blobid_prealloc/2 > blobid_max) {
 	KeyValueDB::Transaction t =
-	  kv_submitting.empty() ? synct : kv_submitting.front()->t;
+	  kv_submitting.empty() ? synct : kv_submitting.front().t;
 	new_blobid_max = blobid_last + cct->_conf->bluestore_blobid_prealloc;
 	bufferlist bl;
 	::encode(new_blobid_max, bl);
 	t->set(PREFIX_SUPER, "blobid_max", bl);
 	dout(10) << __func__ << " new_blobid_max " << new_blobid_max << dendl;
       }
-      for (auto txc : kv_submitting) {
-	assert(txc->state == TransContext::STATE_KV_QUEUED);
-	_txc_finalize_kv(txc, txc->t);
-	txc->log_state_latency(logger, l_bluestore_state_kv_queued_lat);
-	int r = db->submit_transaction(txc->t);
+      for (auto& txc : kv_submitting) {
+	assert(txc.state == TransContext::STATE_KV_QUEUED);
+	_txc_finalize_kv(&txc, txc.t);
+	txc.log_state_latency(logger, l_bluestore_state_kv_queued_lat);
+	int r = db->submit_transaction(txc.t);
 	assert(r == 0);
-	_txc_applied_kv(txc);
-	--txc->osr->kv_committing_serially;
-	txc->state = TransContext::STATE_KV_SUBMITTED;
-	if (txc->osr->kv_submitted_waiters) {
-	  std::lock_guard<std::mutex> l(txc->osr->qlock);
-	  if (txc->osr->_is_all_kv_submitted()) {
-	    txc->osr->qcond.notify_all();
+	_txc_applied_kv(&txc);
+	--txc.osr->kv_committing_serially;
+	txc.state = TransContext::STATE_KV_SUBMITTED;
+	if (txc.osr->kv_submitted_waiters) {
+	  std::lock_guard<std::mutex> l(txc.osr->qlock);
+	  if (txc.osr->_is_all_kv_submitted()) {
+	    txc.osr->qcond.notify_all();
 	  }
 	}
       }
+      // Required for clean TransContext release triggered from txc_state_proc
+      kv_submitting.clear(); 
       uint64_t ops = 0, bytes = 0;
-      for (auto txc : kv_committing) {
-	ops += txc->ops;
-	bytes += txc->bytes;
-	if (txc->had_ios) {
-	  --txc->osr->txc_with_unstable_io;
+      for (auto& txc : kv_committing) {
+	ops += txc.ops;
+	bytes += txc.bytes;
+	if (txc.had_ios) {
+	  --txc.osr->txc_with_unstable_io;
 	}
       }
 
@@ -7799,14 +7810,14 @@ void BlueStore::_kv_sync_thread()
       }
 
       // cleanup sync deferred keys
-      for (auto txc : deferred_stable) {
-	bluestore_deferred_transaction_t& wt = *txc->deferred_txn;
+      for (auto &txc : deferred_stable) {
+	bluestore_deferred_transaction_t& wt = *txc.deferred_txn;
 	if (!wt.released.empty()) {
 	  // kraken replay compat only
-	  txc->released = wt.released;
-	  dout(10) << __func__ << " deferred txn has released " << txc->released
-		   << " (we just upgraded from kraken) on " << txc << dendl;
-	  _txc_finalize_kv(txc, synct);
+	  txc.released = wt.released;
+	  dout(10) << __func__ << " deferred txn has released " << txc.released
+		   << " (we just upgraded from kraken) on " << &txc << dendl;
+	  _txc_finalize_kv(&txc, synct);
 	}
 	// cleanup the deferred
 	string key;
@@ -7863,24 +7874,12 @@ void BlueStore::_kv_sync_thread()
 
       {
 	std::unique_lock<std::mutex> m(kv_finalize_lock);
-	if (kv_committing_to_finalize.empty()) {
-	  kv_committing_to_finalize.swap(kv_committing);
-	} else {
-	  kv_committing_to_finalize.insert(
-	    kv_committing_to_finalize.end(),
-	    kv_committing.begin(),
-	    kv_committing.end());
-	  kv_committing.clear();
-	}
-	if (deferred_stable_to_finalize.empty()) {
-	  deferred_stable_to_finalize.swap(deferred_stable);
-	} else {
-	  deferred_stable_to_finalize.insert(
-	    deferred_stable_to_finalize.end(),
-	    deferred_stable.begin(),
-	    deferred_stable.end());
-          deferred_stable.clear();
-	}
+	kv_committing_to_finalize.splice(
+	  kv_committing_to_finalize.end(),
+	  kv_committing);
+	deferred_stable_to_finalize.splice(
+	  deferred_stable_to_finalize.end(),
+	  deferred_stable);
 	kv_finalize_cond.notify_one();
       }
 
@@ -7895,7 +7894,8 @@ void BlueStore::_kv_sync_thread()
 
 void BlueStore::_kv_finalize_thread()
 {
-  deque<TransContext*> deferred_stable, kv_committed;
+  deferred_queue_t deferred_stable;
+  commit_queue_t kv_committed;
   dout(10) << __func__ << " start" << dendl;
   std::unique_lock<std::mutex> l(kv_finalize_lock);
   while (true) {
@@ -7918,15 +7918,15 @@ void BlueStore::_kv_finalize_thread()
       dout(20) << __func__ << " deferred_stable " << deferred_stable << dendl;
 
       while (!kv_committed.empty()) {
-	TransContext *txc = kv_committed.front();
-	assert(txc->state == TransContext::STATE_KV_SUBMITTED);
-	_txc_state_proc(txc);
+	TransContext &txc = kv_committed.front();
+	assert(txc.state == TransContext::STATE_KV_SUBMITTED);
 	kv_committed.pop_front();
+	_txc_state_proc(&txc);
       }
       while (!deferred_stable.empty()) {
-	TransContext *txc = deferred_stable.front();
-	_txc_state_proc(txc);
+	TransContext &txc = deferred_stable.front();
 	deferred_stable.pop_front();
+	_txc_state_proc(&txc);
       }
 
       if (!deferred_aggressive) {
@@ -8047,7 +8047,7 @@ int BlueStore::_deferred_finish(TransContext *txc)
   bluestore_deferred_transaction_t& wt = *txc->deferred_txn;
   dout(20) << __func__ << " txc " << txc << " seq " << wt.seq << dendl;
 
-  OpSequencer::deferred_queue_t finished;
+  deferred_queue_t finished;
   {
     std::lock_guard<std::mutex> l(deferred_lock);
     assert(txc->osr->deferred_txc == txc);
@@ -8069,9 +8069,11 @@ int BlueStore::_deferred_finish(TransContext *txc)
     txc->osr->qcond.notify_all();
     throttle_deferred_ops.put(txc->ops);
     throttle_deferred_bytes.put(txc->bytes);
-    deferred_done_queue.push_back(txc);
   }
-  finished.clear();
+  deferred_done_queue.splice(deferred_done_queue.end(),
+			     finished,
+			     finished.begin(),
+			     finished.end());
 
   // in the normal case, do not bother waking up the kv thread; it will
   // catch us on the next commit anyway.

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1762,7 +1762,7 @@ private:
   std::atomic<uint64_t> deferred_seq = {0};
   deferred_osr_queue_t deferred_queue; ///< osr's with deferred io pending
   int deferred_queue_size = 0;         ///< num txc's queued across all osrs
-  atomic_bool deferred_aggressive = {false}; ///< aggressive wakeup of kv thread
+  bool deferred_aggressive = false;    ///< aggressive wakeup of kv thread
 
   KVSyncThread kv_sync_thread;
   std::mutex kv_lock;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1453,6 +1453,9 @@ public:
     list<CollectionRef> removed_collections; ///< colls we removed
 
     boost::intrusive::list_member_hook<> deferred_queue_item;
+    boost::intrusive::list_member_hook<> commit_item;
+    boost::intrusive::list_member_hook<> submit_item;
+
     bluestore_deferred_transaction_t *deferred_txn = nullptr; ///< if any
 
     interval_set<uint64_t> allocated, released;
@@ -1546,6 +1549,26 @@ public:
       modified_objects.erase(o);
     }
   };
+  typedef boost::intrusive::list<
+    TransContext,
+    boost::intrusive::member_hook<
+      TransContext,
+        boost::intrusive::list_member_hook<>,
+        &TransContext::deferred_queue_item> > deferred_queue_t;
+
+  typedef boost::intrusive::list<
+    TransContext,
+    boost::intrusive::member_hook<
+    TransContext,
+    boost::intrusive::list_member_hook<>,
+    &TransContext::commit_item> > commit_queue_t;
+
+  typedef boost::intrusive::list<
+    TransContext,
+    boost::intrusive::member_hook<
+    TransContext,
+    boost::intrusive::list_member_hook<>,
+    &TransContext::submit_item> > submit_queue_t;
 
   class OpSequencer : public Sequencer_impl {
   public:
@@ -1559,12 +1582,6 @@ public:
 	&TransContext::sequencer_item> > q_list_t;
     q_list_t q;  ///< transactions
 
-    typedef boost::intrusive::list<
-      TransContext,
-      boost::intrusive::member_hook<
-	TransContext,
-	boost::intrusive::list_member_hook<>,
-	&TransContext::deferred_queue_item> > deferred_queue_t;
     deferred_queue_t deferred_pending;      ///< waiting
     deferred_queue_t deferred_running;      ///< in flight ios
     interval_set<uint64_t> deferred_blocks; ///< blocks in flight
@@ -1768,17 +1785,17 @@ private:
   std::mutex kv_lock;
   std::condition_variable kv_cond, kv_sync_cond;
   bool kv_stop = false;
-  deque<TransContext*> kv_queue;             ///< ready, already submitted
-  deque<TransContext*> kv_queue_unsubmitted; ///< ready, need submit by kv thread
-  deque<TransContext*> kv_committing;        ///< currently syncing
-  deque<TransContext*> deferred_done_queue;    ///< deferred ios done
-  deque<TransContext*> deferred_stable_queue;  ///< deferred ios done + stable
+
+
+  commit_queue_t kv_queue;		///< ready, already submitted
+  submit_queue_t kv_queue_unsubmitted;	///< ready, need submit by kv thread
+  deferred_queue_t deferred_done_queue;    	///< deferred ios done
 
   KVFinalizeThread kv_finalize_thread;
   std::mutex kv_finalize_lock;
   std::condition_variable kv_finalize_cond;
-  deque<TransContext*> kv_committing_to_finalize;   ///< pending finalization
-  deque<TransContext*> deferred_stable_to_finalize; ///< pending finalization
+  commit_queue_t kv_committing_to_finalize;   	    ///< pending finalization
+  deferred_queue_t deferred_stable_to_finalize;	    ///< pending finalization
 
   PerfCounters *logger = nullptr;
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1692,6 +1692,14 @@ public:
       return NULL;
     }
   };
+  struct KVFinalizeThread : public Thread {
+    BlueStore *store;
+    explicit KVFinalizeThread(BlueStore *s) : store(s) {}
+    void *entry() {
+      store->_kv_finalize_thread();
+      return NULL;
+    }
+  };
 
   struct DBHistogram {
     struct value_dist {
@@ -1769,6 +1777,12 @@ private:
   deque<TransContext*> kv_committing;        ///< currently syncing
   deque<TransContext*> deferred_done_queue;    ///< deferred ios done
   deque<TransContext*> deferred_stable_queue;  ///< deferred ios done + stable
+
+  KVFinalizeThread kv_finalize_thread;
+  std::mutex kv_finalize_lock;
+  std::condition_variable kv_finalize_cond;
+  deque<TransContext*> kv_committing_to_finalize;   ///< pending finalization
+  deque<TransContext*> deferred_stable_to_finalize; ///< pending finalization
 
   PerfCounters *logger = nullptr;
 
@@ -1913,13 +1927,20 @@ private:
   void _osr_unregister_all();
 
   void _kv_sync_thread();
+  void _kv_finalize_thread();
   void _kv_stop() {
     {
       std::lock_guard<std::mutex> l(kv_lock);
       kv_stop = true;
       kv_cond.notify_all();
     }
+    {
+      std::lock_guard<std::mutex> l(kv_finalize_lock);
+      kv_finalize_cond.notify_all();
+    }
+
     kv_sync_thread.join();
+    kv_finalize_thread.join();
     {
       std::lock_guard<std::mutex> l(kv_lock);
       kv_stop = false;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -33,7 +33,6 @@
 #include "include/unordered_map.h"
 #include "include/memory.h"
 #include "include/mempool.h"
-#include "common/Finisher.h"
 #include "common/perf_counters.h"
 #include "compressor/Compressor.h"
 #include "os/ObjectStore.h"
@@ -1764,9 +1763,6 @@ private:
   deferred_osr_queue_t deferred_queue; ///< osr's with deferred io pending
   int deferred_queue_size = 0;         ///< num txc's queued across all osrs
   atomic_bool deferred_aggressive = {false}; ///< aggressive wakeup of kv thread
-
-  int m_finisher_num = 1;
-  vector<Finisher*> finishers;
 
   KVSyncThread kv_sync_thread;
   std::mutex kv_lock;

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -106,6 +106,8 @@ bluestore=0
 rgw_frontend="civetweb"
 lockdep=${LOCKDEP:-1}
 
+filestore_path=
+
 VSTART_SEC="client.vstart.sh"
 
 MON_ADDR=""
@@ -240,6 +242,10 @@ case $1 in
             rgw_frontend=$2
             shift
             ;;
+    --filestore_path )
+	filestore_path=$2
+	shift
+	;;
     -m )
 	    [ -z "$2" ] && usage_exit
 	    MON_ADDR=$2
@@ -565,7 +571,11 @@ EOF
             if command -v btrfs > /dev/null; then
                 for f in $CEPH_DEV_DIR/osd$osd/*; do btrfs sub delete $f &> /dev/null || true; done
             fi
-            mkdir -p $CEPH_DEV_DIR/osd$osd
+	    if [ -n "$filestore_path" ]; then
+		ln -s $filestore_path $CEPH_DEV_DIR/osd$osd
+	    else
+		mkdir -p $CEPH_DEV_DIR/osd$osd
+	    fi
 
             local uuid=`uuidgen`
             echo "add osd$osd $uuid"


### PR DESCRIPTION
This is somewhat hackery approach to merge multiple TransContexts into a single batch to submit them in a single step. The code relies on RocksDB WriteBatch internals to merge multiple batches into a single one. Unfortunately more elegant solution to collect operations out of RocksDB WriteBatch and then build it from scratch isn't beneficial  from performance POV as we overburden kv_sync_thread. (See code at (https://github.com/ifed01/ceph/tree/wip-bluestore-large-batch-prod)
This PR is actually a question if we want to proceed this way as well as a summary on obtained numbers.
Results below are for FIO bluestore plugin for both highly concurrent 4K appends and overwrites using 2 NVME drives. (min_alloc_size=4K too). Each case was run for 3 times

Original code (kv_finisher tread PR + intrusive lists for TransContextx)
Append: 
Run 1 = 370 Mb/s , run 2  = 367 Mb/s, run3 = 358 Mb/s
Overwrite:
Run 1 = 329 Mb/s , run 2  = 333 Mb/s, run3 = 329 Mb/s

This PR code on top of above-mentioned original one
Append: 
Run 1 = 419 Mb/s , run 2  = 413 Mb/s, run3 = 420 Mb/s
Overwrite:
Run 1 = 338 Mb/s , run 2  = 338 Mb/s, run3 = 345 Mb/s

Failed approach to collect KV operations out of RocksDB and build a resulting batch before the submit
Append: 
Run 1 = 368 Mb/s , run 2  = 375 Mb/s, run3 = 373 Mb/s
Overwrite:
Run 1 = 270 Mb/s , run 2  = 272 Mb/s, run3 = 278 Mb/s

