### PR TITLE
mon: handle MStatfs using PGStatService

### DIFF
--- a/src/mon/MgrStatMonitor.cc
+++ b/src/mon/MgrStatMonitor.cc
@@ -36,6 +36,10 @@ public:
     return digest.get_num_pg_by_osd(osd);
   }
 
+  ceph_statfs get_statfs() const override {
+    return digest.get_statfs();
+  }
+
   void print_summary(Formatter *f, ostream *out) const override {
     digest.print_summary(f, out);
   }

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -666,6 +666,7 @@ public:
   void handle_get_version(MonOpRequestRef op);
   void handle_subscribe(MonOpRequestRef op);
   void handle_mon_get_map(MonOpRequestRef op);
+  void handle_statfs(MonOpRequestRef op);
 
   static void _generate_command_map(map<string,cmd_vartype>& cmdmap,
                                     map<string,string> &param_str_map);

--- a/src/mon/PGMap.h
+++ b/src/mon/PGMap.h
@@ -167,6 +167,16 @@ public:
       return p->second.primary;
   }
 
+  ceph_statfs get_statfs() const {
+    ceph_statfs statfs;
+    // these are in KB.
+    statfs.kb = osd_sum.kb;
+    statfs.kb_used = osd_sum.kb_used;
+    statfs.kb_avail = osd_sum.kb_avail;
+    statfs.num_objects = pg_sum.stats.sum.num_objects;
+    return statfs;
+  }
+
   int64_t get_rule_avail(const OSDMap& osdmap, int ruleno) const;
 
   // kill me post-luminous:

--- a/src/mon/PGMonitor.h
+++ b/src/mon/PGMonitor.h
@@ -77,7 +77,6 @@ private:
 
   struct C_Stats;
 
-  void handle_statfs(MonOpRequestRef op);
   bool preprocess_getpoolstats(MonOpRequestRef op);
 
   bool preprocess_command(MonOpRequestRef op);

--- a/src/mon/PGStatService.h
+++ b/src/mon/PGStatService.h
@@ -84,6 +84,7 @@ public:
   }
 
   virtual size_t get_num_pg_by_osd(int osd) const = 0;
+  virtual ceph_statfs get_statfs() const = 0;
   virtual void print_summary(Formatter *f, ostream *out) const = 0;
   virtual void dump_info(Formatter *f) const = 0;
   virtual void dump_fs_stats(stringstream *ss, Formatter *f, bool verbose) const = 0;


### PR DESCRIPTION
otherwise ceph_test_rados_api_stat: LibRadosStat.ClusterStat will always
timeout once the cluster is switched to luminous

Signed-off-by: Kefu Chai <kchai@redhat.com>