### PR TITLE
mon/OSDMonitor: filter the added creating_pgs added from pgmap

### DIFF
--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -1148,12 +1148,17 @@ class CephManager:
                   "-w"],
             wait=False, stdout=StringIO(), stdin=run.PIPE)
 
-    def flush_pg_stats(self, osds, wait_for_mon=3*5):
+    def flush_pg_stats(self, osds, no_wait=None, wait_for_mon=3*5):
         """
         Flush pg stats from a list of OSD ids, ensuring they are reflected
         all the way to the monitor.  Luminous and later only.
 
         :param osds: list of OSDs to flush
+        :param no_wait: list of OSDs not to wait for seq id. by default, we
+                        wait for all specified osds, but some of them could be
+                        moved out of osdmap, so we cannot get their updated
+                        stat seq from monitor anymore. in that case, you need
+                        to pass a blacklist.
         :param wait_for_mon: wait for mon to be synced with mgr. 0 to disable
                              it. (3 * mon_mgr_digest_period, by default)
         """
@@ -1161,7 +1166,11 @@ class CephManager:
                for osd in osds}
         if not wait_for_mon:
             return
+        if no_wait is None:
+            no_wait = []
         for osd, need in seq.iteritems():
+            if osd in no_wait:
+                continue
             got = 0
             while wait_for_mon > 0:
                 got = self.raw_cluster_cmd('osd', 'last-stat-seq', 'osd.%d' % osd)

--- a/qa/tasks/osd_recovery.py
+++ b/qa/tasks/osd_recovery.py
@@ -141,7 +141,7 @@ def test_incomplete_pgs(ctx, config):
 
     # move data off of osd.0, osd.1
     manager.raw_cluster_cmd('osd', 'out', '0', '1')
-    manager.flush_pg_stats([0, 1, 2, 3])
+    manager.flush_pg_stats([0, 1, 2, 3], [0, 1])
     manager.wait_for_clean()
 
     # lots of objects in rbd (no pg log, will backfill)
@@ -160,7 +160,7 @@ def test_incomplete_pgs(ctx, config):
     manager.raw_cluster_cmd('osd', 'in', '0', '1')
     manager.raw_cluster_cmd('osd', 'out', '2', '3')
     time.sleep(10)
-    manager.flush_pg_stats([0, 1, 2, 3])
+    manager.flush_pg_stats([0, 1, 2, 3], [2, 3])
     time.sleep(10)
     manager.wait_for_active()
 

--- a/selinux/ceph.fc
+++ b/selinux/ceph.fc
@@ -1,6 +1,7 @@
 /etc/rc\.d/init\.d/ceph		--	gen_context(system_u:object_r:ceph_initrc_exec_t,s0)
 /etc/rc\.d/init\.d/radosgw	--	gen_context(system_u:object_r:ceph_initrc_exec_t,s0)
 
+/usr/bin/ceph-mgr		--	gen_context(system_u:object_r:ceph_exec_t,s0)
 /usr/bin/ceph-mon		--	gen_context(system_u:object_r:ceph_exec_t,s0)
 /usr/bin/ceph-mds		--	gen_context(system_u:object_r:ceph_exec_t,s0)
 /usr/bin/ceph-osd		--	gen_context(system_u:object_r:ceph_exec_t,s0)

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -955,6 +955,7 @@ OSDMonitor::update_pending_pgs(const OSDMap::Incremental& inc)
 	osdmap.require_osd_release < CEPH_RELEASE_LUMINOUS) {
       auto added =
 	mon->pgservice->maybe_add_creating_pgs(creating_pgs.last_scan_epoch,
+					       osdmap.get_pools(),
 					       &pending_creatings);
       dout(7) << __func__ << " " << added << " pgs added from pgmap" << dendl;
     }

--- a/src/mon/PGMonitor.cc
+++ b/src/mon/PGMonitor.cc
@@ -1209,12 +1209,17 @@ public:
     return pgmap.creating_pgs.count(pgid);
   }
   unsigned maybe_add_creating_pgs(epoch_t scan_epoch,
-			      creating_pgs_t *pending_creates) const override {
+     const mempool::osdmap::map<int64_t,pg_pool_t>& pools,
+     creating_pgs_t *pending_creates) const override
+  {
     if (pgmap.last_pg_scan < scan_epoch) {
       return 0;
     }
     unsigned added = 0;
     for (auto& pgid : pgmap.creating_pgs) {
+      if (!pools.count(pgid.pool())) {
+	continue;
+      }
       auto st = pgmap.pg_stat.find(pgid);
       assert(st != pgmap.pg_stat.end());
       auto created = make_pair(st->second.created,

--- a/src/mon/PGStatService.h
+++ b/src/mon/PGStatService.h
@@ -64,7 +64,8 @@ public:
    * creating_pgs (scan_epoch), insert them into the passed pending_creates.
    */
   virtual unsigned maybe_add_creating_pgs(epoch_t scan_epoch,
-					  creating_pgs_t *pending_creates) const {
+     const mempool::osdmap::map<int64_t,pg_pool_t>& pools,
+     creating_pgs_t *pending_creates) const {
     ceph_abort();
     return 0;
   }


### PR DESCRIPTION
    the creating_pgs added from pgmap might contains pgs whose containing
    pools have been deleted. this is fine with the PGMonitor, as it has the
    updated pg mapping which is consistent with itself. but it does not work
    with OSDMonitor's creating_pgs, whose pg mapping is calculated by
    itself. so we need to filter the pgmap's creating_pgs when adding them to
    OSDMonitor's creating_pgs with the latest osdmap.get_pools().

Fixes: http://tracker.ceph.com/issues/20067

@liewegas 