### PR TITLE
Better algorithm for optimization in 'crush-compat' mode

### DIFF
--- a/doc/man/8/ceph.rst
+++ b/doc/man/8/ceph.rst
@@ -161,6 +161,87 @@ Usage::
 
 	ceph auth print_key <entity>
 
+balancer
+--------
+
+Manage reweight optimizations and balancing. It is used to remove any
+uneven utilization of OSDs in a cluster.
+
+Subcommand ``on`` starts auto-magic (online and incremental) balancing.
+
+Usage::
+
+	ceph balancer on
+
+Subcommand ``status`` shows balancer configurations and existing plans.
+
+Usage::
+
+	ceph balancer status
+
+Subcommand ``mode`` sets mode of operation.
+
+Usage::
+
+	ceph mds mode crush-compat|upmap|none
+
+Subcommand ``optimize`` creates a new optimization plan.
+
+Usage::
+
+	ceph balancer optimize <plan>
+
+Subcommand ``eval`` evaluates the expected utilization of OSDs if the
+optimization plan is actually implemented. If no plan is specified, it
+evaluates the current utilization of OSDs.
+
+Usage::
+
+	ceph balancer eval {<plan>}
+
+Subcommand ``show`` displays the cli implementations of the plan.
+
+Usage::
+
+	ceph balancer show <plan>
+
+Subcommand ``execute`` implements the plan through ``mon`` commands.
+
+Usage::
+
+	ceph balancer execute <plan>
+
+Subcommand ``rm`` removes a plan from the memory.
+
+Usage::
+
+	ceph balancer rm <plan>
+
+Subcommand ``key`` configures the optimization parameter.
+
+Usage::
+
+	ceph balancer key pgs|objects|bytes|auto
+
+Subcommand ``key-weights`` configures key weights in case the key was `auto`.
+
+Usage::
+
+	ceph balancer key-weights <int[0-]> <int[0-]> <int[0-]>
+
+Subcommand ``max-iterations`` configures the maximum number of times the
+iterative algorithm may run before it results in the new weights.
+
+Usage::
+
+	ceph balancer max-iterations <int[1-]>
+
+Subcommand ``off`` stops auto-magic balancing.
+
+Usage::
+
+	ceph balancer off
+
 
 compact
 -------

--- a/doc/mgr/balancer.rst
+++ b/doc/mgr/balancer.rst
@@ -1,0 +1,273 @@
+balancer plugin
+================
+
+Typically, if you say, the system is 70% filled, then, all the OSDs,
+should be 70% filled (roughly). It shouldn’t be the case that, a particular
+OSD is 90% filled whereas another one is 20% filled. If such a case exist,
+then we say there is an uneven distribution. Uneven distribution may arise
+out of a number of reasons, including improper distribution of PGs among the
+OSDs. Even if the PGs, were balanced properly, with respect to the weights
+of the OSDs, there is still chance of uneven distribution, because the number
+of objects assigned to different PGs are not in required proportion. And even
+if they were, the sizes of each object might vary.
+
+The balancer plugin will automatically optimize the pg (or objects or byte-level)
+distribution.  One needs to just turn it on and it will slowly and continuously
+optimize the layout without the user having to think about it. In this case, optimization
+means, changing the weights of the devices (OSDs), so that the right amount of PGs, get
+mapped to each device, with respect to their relative weights. If one wanted to attain
+byte-level even-distribution, they would have to change the key (``ceph balancer key``)
+to `byte`. It is however, suggested that the key be set to `auto` mode, with weights for
+each parameter.
+
+While it is recommended that the balancer module be best left to run auto-magically,
+it might interest certain users to turn off the automatic optimization, and instead
+create optimization plans themselves, and execute them, whenever they feel the need
+to do so. While there is no fixed way to determine when to execute the rebalance
+plan, the *score* of the system on each parameter and the average score (can be
+viewed using ``balancer eval``) will give a general idea as to how uneven the
+current distribution is. The lower the score, the better the distribution,
+with 0 meaning perfect distribution, and 1 meaning the average over-utilized device
+is infinitely more weighted than the average utilization of all devices.
+
+As a rule of thumb, if score is 0.08, then the average over-utilized device is 10%
+over-weighted compared to the average utilization of all OSDs, and a score of 0.68
+implies 100% more weighted. The scoring is non-linear, to signify that presence of
+highly over-utilizaed devices is a pretty bad situation.
+
+Working Process and Performance
+-------------------------------
+
+At each instance of optimization, balancer module creates a `Plan`. Then it uses the
+CRUSH to identify the various OSDs in a pool and calculate the distribution of `pg`,
+`bytes` and `objects`, from the OSDMap. Then it calculates, how the target distribution
+of each of the parameter(`pg`, `bytes` and `objects`). Using an iterative gradient
+descent algorithm it tries to calculate the new weights. In each step of iteration,
+the module checks that the process has converged to the new-weights or not, by calculating
+their expected distribution, should the weights get implemented. If the process converged,
+or the maximum number of iterations were made, then the best-weights during the entire
+process is recorded in the plan. The module then sends a `Mon` command, to actually
+execute the new-weights, and then remove the plan from the memory. If the balancer is
+set on automagic mode, this entire process, gets repeated until automagic mode is turned off.
+There is a single threshold, max_misplaced, that controls what fraction of the PGs/objects
+can be misplaced at once. Default is 3%. However, with automagic mode, one should expect
+continous movement of data across the network, almost all the time. Again, the amount of
+data that moves at any given time, can be limited using `max_misplaced` parameter.
+
+The balancer module works with multiple roots, device classes, multiple takes in the CRUSH rules.
+There is some restrictions, though, depending on the mode. Notably, the crush-compat only
+has a single set of weights to adjust, so it can't do much if there are multiple hierarchies
+being balanced that overlap over any of the same devices.
+
+Before we can execute any new-weights, we model the size of each pg so that we can
+tell how things change when we move pgs. It uses the pg stats (obtained from using
+a private copy of the OSDMap), but that is an incomplete solution because we don't
+properly account for omap data. There is also some storage overhead in the OSD itself
+(e.g., bluestore metadata, osdmaps, per-pg metatata). Although, this should work reasonably
+well as long as you're not mixing omap and non-omap pools on the same devices but via
+different subtrees).
+
+It's probably worth mentioning that the balancer wouldn't actually export/import crush maps.
+Instead, once it decides what weight adjustments to make, it will just issue normal monitor
+commands to initiate those changes. Currently, there is no option for revert, for practical reasons
+because the balancer will make small adjustments to weights over time, but mixed in with that may
+be various other changes due to cluster expansion/contraction or admin changes or whatever.
+
+Additionally, the module doesn't over-ride any other configuration, except for `max_misplaced`
+parameter in the module, which behaves as the same as `max_change` in `Mon` global configurations.
+The `max_misplaced` simply restricts a significant movement of data, all at once.
+
+Enabling
+--------
+
+The *balancer* module is enabled with::
+
+  ceph mgr module enable balancer
+
+Configuration
+-------------
+The basics::
+
+  ceph balancer mode crush-compat|upmap|none
+
+:Description: For versions previous than Luminous 'osd_weight' mode is under-progress.
+	      If Ceph version is greater than Luminous v12.2.z, 'upmap' mode is suggested.
+	      If Ceph version is Luminous but you wish to be able to generate a backward
+	      compatible crush-map, then 'crush-compat' mode is suggested.
+:Type: Choices (String)
+:Required: Yes.
+
+Usage
+-----
+A normal user will be expected to just set the mode and turn it on::
+
+  ceph balancer mode crush-compat
+  ceph balancer on
+
+An advanced user can play with different optimizer modes etc and see what
+they will actually do before making any changes to their cluster.
+
+Automagic mode
+--------------
+After the user has set the required configuration, he/she can run the balancer
+module auto-magically, in which case, the module, will constantly evaluate the unevenness
+in the distribution and try to remove it with small incremental changes::
+
+  ceph balancer on
+
+To stop running the balancer module in auto-magic mode::
+
+  ceph balancer off
+
+Checking status
+---------------
+To see any existing plans, key-weights of different parameters, mode of operation,
+key parameter, whether the module is enabled and current max-iterations::
+
+  ceph balancer status
+
+Sample output of `ceph balancer status`::
+
+  {
+  "plans": ["planB", "planA"],
+  "key-weights": [5, 3, 2],
+  "mode": "none",
+  "key": "pgs",
+  "active": false,
+  "max-iterations": 100
+  }
+
+Checkng distribution
+--------------------
+Show analysis of current data distribution on different parameters and average score::
+
+  ceph balancer eval
+
+Sample Output from `ceph balancer eval`::
+
+  current cluster
+  target_by_root {'default':
+  {0: 0.3333333432674408, 1: 0.3333333432674408, 2: 0.3333333432674408}}
+  actual_by_pool {
+  cephfs_data_a': {
+  'objects': {0: 0.0, 1: 0.0, 2: 0.0},
+  'bytes': {0: 0.0, 1: 0.0, 2: 0.0},
+  'pgs': {0: 0.3333333333333333, 1: 0.3333333333333333, 2: 0.3333333333333333}}
+  (.....)
+  stats_by_root {
+  'default': {
+  'objects': {'avg': 21.0, 'score': 0.0, 'stddev': 7.665050497418206e-07},
+  'bytes': {'avg': 2246.0, 'score': 0.0, 'stddev': 8.19795396240023e-05},
+  'pgs': {'avg': 16.0, 'score': 0.0, 'stddev': 5.840038465935456e-07}}}
+  score_by_pool {}
+  score_by_root {'default': {'objects': 0.0, 'bytes': 0.0, 'pgs': 0.0}}
+  score 0.000000 (lower is better)
+
+
+Configuring keys
+----------------
+To set the parameter on which the optimization is decided::
+
+  ceph balancer key pgs|objects|bytes|auto
+
+:Description: Determines what parameter to optimize upon. If key is auto, then the user
+	      may additionally specify key-weights to give relative weights to optimization
+	      on these parameters. For example, if the key was pgs, then the balancer module
+	      to try to keep the distribution of PGs perfect with respect to the weights of
+	      the OSDs, even if that may lead to uneven distribution of bytes.
+:Type: Choices (String)
+:Required: Yes.
+:Default:  pgs
+
+To set key-weights for auto-mode::
+
+  ceph balancer key-weights <pg-weight> <object-weight> <byte-weight>
+
+Where:
+
+``{pg-weight}``, ``{object-weight}``, ``{byte-weight}``
+
+:Description: Specify the weights to each of the three paramters, if the key is auto.
+	      In general, it is better to keep the pg-weight as highest, compared to
+	      the other two. pg-weight will ensure a better distribution of PG first,
+	      hence the chances of uneven distribution creeping up in future gets reduced.
+	      The relative priority is left to the user, with an initial relative weights
+	      of [5, 3, 2] and in that order. The key-weights have no significance when
+	      the key is not `auto`.
+:Type: Integer
+:Required: Yes
+:Default:  [5, 3, 2]
+
+To set max-iterations::
+
+  ceph balancer max-iterations {max-iterations}
+
+Where:
+
+``{max-iterations}``
+
+:Description: The optimization algorithm, uses an iterative algorithm to decide the new
+	      weights for the devices. The max-iteration will limit the number of times
+	      the iteration will run. More often than not the new weights (converged) are
+	      determined before 100 iterations. However, in the odd-case, that results might
+	      not converge before 100 iterations, the user may wish to increase to some greater
+	      value. Obviously, the higher the value, the more time it requires, in one-off odd-cases.
+:Type: Integer
+:Required: Yes.
+:Default:  100
+
+Plan
+====
+
+Each instance of optimization, creates a Plan. A plan takes the configuration of the balancer
+module at the time it was created, and creates a new instance of `OSDMap::Incremental`. A plan is
+used to store the new-weights that we arrive at, and exposes functionality to evaluate the
+expected distribution, should the new weights get executed. When in automagic mode, plans get created,
+executed and removed on the fly. However, one can create any number of Plans, as long as each plan
+has a different name.
+
+Creating Plan
+-------------
+To create a new plan to optimize, based on the current mode::
+
+  ceph balancer optimize {plan}
+
+Where:
+
+``{plan}``
+
+:Description: Name of the new plan. The plans currently get lost if ceph-mgr daemon restarts
+:Type: String
+:Required: Yes.
+
+Evaluating a Plan
+-----------------
+To roughly predict the resulting distribution, if the plan is executed::
+
+  ceph balancer eval <plan>
+
+To list all the plans that are currently present in the memory, see `Checking Status`_.
+
+To show what the plan would do (basically a dump of cli commands to adjust weights etc)::
+
+  ceph balancer show <plan>
+
+Where:
+
+``{plan}``
+
+:Description: Name of an existing plan.
+:Type: String
+:Required: Yes.
+
+Executing a Plan
+----------------
+To execute a plan and then discard it (this will lead to actual movement of data across the OSDs)::
+
+  ceph balancer execute <plan>
+
+Removing a Plan
+---------------
+To remove a plan from the list of plans::
+
+  ceph balancer rm <plan>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -688,6 +688,7 @@ if (WITH_MGR)
       mgr/ClusterState.cc
       mgr/PyModules.cc
       mgr/PyFormatter.cc
+      mgr/PyOSDMap.cc
       mgr/PyState.cc
       mgr/MgrPyModule.cc
       mgr/MgrStandby.cc

--- a/src/crush/CrushTreeDumper.h
+++ b/src/crush/CrushTreeDumper.h
@@ -68,7 +68,7 @@ namespace CrushTreeDumper {
     explicit Dumper(const CrushWrapper *crush_,
 		    const name_map_t& weight_set_names_)
       : crush(crush_), weight_set_names(weight_set_names_) {
-      crush->find_nonshadow_roots(roots);
+      crush->find_nonshadow_roots(&roots);
       root = roots.begin();
     }
 

--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -291,7 +291,7 @@ int CrushWrapper::rename_bucket(const string& srcname,
   return set_item_name(oldid, dstname);
 }
 
-void CrushWrapper::find_takes(set<int>& roots) const
+void CrushWrapper::find_takes(set<int> *roots) const
 {
   for (unsigned i=0; i<crush->max_rules; i++) {
     crush_rule *r = crush->rules[i];
@@ -299,23 +299,23 @@ void CrushWrapper::find_takes(set<int>& roots) const
       continue;
     for (unsigned j=0; j<r->len; j++) {
       if (r->steps[j].op == CRUSH_RULE_TAKE)
-	roots.insert(r->steps[j].arg1);
+	roots->insert(r->steps[j].arg1);
     }
   }
 }
 
-void CrushWrapper::find_roots(set<int>& roots) const
+void CrushWrapper::find_roots(set<int> *roots) const
 {
   for (int i = 0; i < crush->max_buckets; i++) {
     if (!crush->buckets[i])
       continue;
     crush_bucket *b = crush->buckets[i];
     if (!_search_item_exists(b->id))
-      roots.insert(b->id);
+      roots->insert(b->id);
   }
 }
 
-void CrushWrapper::find_nonshadow_roots(set<int>& roots) const
+void CrushWrapper::find_nonshadow_roots(set<int> *roots) const
 {
   for (int i = 0; i < crush->max_buckets; i++) {
     if (!crush->buckets[i])
@@ -326,7 +326,7 @@ void CrushWrapper::find_nonshadow_roots(set<int>& roots) const
     const char *name = get_item_name(b->id);
     if (name && !is_valid_crush_name(name))
       continue;
-    roots.insert(b->id);
+    roots->insert(b->id);
   }
 }
 
@@ -1381,7 +1381,7 @@ bool CrushWrapper::class_is_in_use(int class_id)
 int CrushWrapper::populate_classes()
 {
   set<int> roots;
-  find_roots(roots);
+  find_roots(&roots);
   for (auto &r : roots) {
     if (r >= 0)
       continue;
@@ -1405,7 +1405,7 @@ int CrushWrapper::cleanup_classes()
 int CrushWrapper::trim_roots_with_class(bool unused)
 {
   set<int> roots;
-  find_roots(roots);
+  find_roots(&roots);
   for (auto &r : roots) {
     if (r >= 0)
       continue;
@@ -1449,7 +1449,7 @@ int32_t CrushWrapper::_alloc_class_id() const {
 void CrushWrapper::reweight(CephContext *cct)
 {
   set<int> roots;
-  find_roots(roots);
+  find_roots(&roots);
   for (set<int>::iterator p = roots.begin(); p != roots.end(); ++p) {
     if (*p >= 0)
       continue;
@@ -2387,7 +2387,7 @@ namespace {
 
     void dump(Formatter *f) {
       set<int> roots;
-      crush->find_roots(roots);
+      crush->find_roots(&roots);
       for (set<int>::iterator root = roots.begin(); root != roots.end(); ++root) {
 	dump_item(Item(*root, 0, 0, crush->get_bucket_weightf(*root)), f);
       }

--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -1577,7 +1577,56 @@ int CrushWrapper::add_simple_rule(
 			    rule_type, -1, err);
 }
 
-int CrushWrapper::get_rule_weight_osd_map(unsigned ruleno, map<int,float> *pmap)
+float CrushWrapper::_get_take_weight_osd_map(int root,
+					     map<int,float> *pmap) const
+{
+  float sum = 0.0;
+  list<int> q;
+  q.push_back(root);
+  //breadth first iterate the OSD tree
+  while (!q.empty()) {
+    int bno = q.front();
+    q.pop_front();
+    crush_bucket *b = crush->buckets[-1-bno];
+    assert(b);
+    for (unsigned j=0; j<b->size; ++j) {
+      int item_id = b->items[j];
+      if (item_id >= 0) { //it's an OSD
+	float w = crush_get_bucket_item_weight(b, j);
+	(*pmap)[item_id] = w;
+	sum += w;
+      } else { //not an OSD, expand the child later
+	q.push_back(item_id);
+      }
+    }
+  }
+  return sum;
+}
+
+void CrushWrapper::_normalize_weight_map(float sum,
+					 const map<int,float>& m,
+					 map<int,float> *pmap) const
+{
+  for (auto& p : m) {
+    map<int,float>::iterator q = pmap->find(p.first);
+    if (q == pmap->end()) {
+      (*pmap)[p.first] = p.second / sum;
+    } else {
+      q->second += p.second / sum;
+    }
+  }
+}
+
+int CrushWrapper::get_take_weight_osd_map(int root, map<int,float> *pmap) const
+{
+  map<int,float> m;
+  float sum = _get_take_weight_osd_map(root, &m);
+  _normalize_weight_map(sum, m, pmap);
+  return 0;
+}
+
+int CrushWrapper::get_rule_weight_osd_map(unsigned ruleno,
+					  map<int,float> *pmap) const
 {
   if (ruleno >= crush->max_rules)
     return -ENOENT;
@@ -1600,35 +1649,10 @@ int CrushWrapper::get_rule_weight_osd_map(unsigned ruleno, map<int,float> *pmap)
 	m[n] = 1.0;
 	sum = 1.0;
       } else {
-	list<int> q;
-	q.push_back(n);
-	//breadth first iterate the OSD tree
-	while (!q.empty()) {
-	  int bno = q.front();
-	  q.pop_front();
-	  crush_bucket *b = crush->buckets[-1-bno];
-	  assert(b);
-	  for (unsigned j=0; j<b->size; ++j) {
-	    int item_id = b->items[j];
-	    if (item_id >= 0) { //it's an OSD
-	      float w = crush_get_bucket_item_weight(b, j);
-	      m[item_id] = w;
-	      sum += w;
-	    } else { //not an OSD, expand the child later
-	      q.push_back(item_id);
-	    }
-	  }
-	}
+	sum += _get_take_weight_osd_map(n, &m);
       }
     }
-    for (map<int,float>::iterator p = m.begin(); p != m.end(); ++p) {
-      map<int,float>::iterator q = pmap->find(p->first);
-      if (q == pmap->end()) {
-	(*pmap)[p->first] = p->second / sum;
-      } else {
-	q->second += p->second / sum;
-      }
-    }
+    _normalize_weight_map(sum, m, pmap);
   }
 
   return 0;

--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -1006,6 +1006,12 @@ public:
     return s->arg2;
   }
 
+private:
+  float _get_take_weight_osd_map(int root, map<int,float> *pmap) const;
+  void _normalize_weight_map(float sum, const map<int,float>& m,
+			     map<int,float> *pmap) const;
+
+public:
   /**
    * calculate a map of osds to weights for a given rule
    *
@@ -1016,7 +1022,19 @@ public:
    * @param pmap [out] map of osd to weight
    * @return 0 for success, or negative error code
    */
-  int get_rule_weight_osd_map(unsigned ruleno, map<int,float> *pmap);
+  int get_rule_weight_osd_map(unsigned ruleno, map<int,float> *pmap) const;
+
+  /**
+   * calculate a map of osds to weights for a given starting root
+   *
+   * Generate a map of which OSDs get how much relative weight for a
+   * given starting root
+   *
+   * @param root node
+   * @param pmap [out] map of osd to weight
+   * @return 0 for success, or negative error code
+   */
+  int get_take_weight_osd_map(int root, map<int,float> *pmap) const;
 
   /* modifiers */
 

--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -588,14 +588,14 @@ public:
    *
    * Note that these may not be parentless roots.
    */
-  void find_takes(set<int>& roots) const;
+  void find_takes(set<int> *roots) const;
 
   /**
    * find tree roots
    *
    * These are parentless nodes in the map.
    */
-  void find_roots(set<int>& roots) const;
+  void find_roots(set<int> *roots) const;
 
   /**
    * find tree roots that are not shadow (device class) items
@@ -603,7 +603,7 @@ public:
    * These are parentless nodes in the map that are not shadow
    * items for device classes.
    */
-  void find_nonshadow_roots(set<int>& roots) const;
+  void find_nonshadow_roots(set<int> *roots) const;
 
   /**
    * see if an item is contained within a subtree

--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -965,6 +965,17 @@ public:
       return true;
     return false;
   }
+  bool rule_has_take(unsigned ruleno, int take) const {
+    if (!crush) return false;
+    crush_rule *rule = get_rule(ruleno);
+    for (unsigned i = 0; i < rule->len; ++i) {
+      if (rule->steps[i].op == CRUSH_RULE_TAKE &&
+	  rule->steps[i].arg1 == take) {
+	return true;
+      }
+    }
+    return false;
+  }
   int get_rule_len(unsigned ruleno) const {
     crush_rule *r = get_rule(ruleno);
     if (IS_ERR(r)) return PTR_ERR(r);

--- a/src/mgr/MgrPyModule.cc
+++ b/src/mgr/MgrPyModule.cc
@@ -12,6 +12,7 @@
  */
 
 #include "PyState.h"
+#include "PyOSDMap.h"
 #include "Gil.h"
 
 #include "PyFormatter.h"
@@ -109,6 +110,9 @@ MgrPyModule::MgrPyModule(const std::string &module_name_, const std::string &sys
     }
     // Populate python namespace with callable hooks
     Py_InitModule("ceph_state", CephStateMethods);
+    Py_InitModule("ceph_osdmap", OSDMapMethods);
+    Py_InitModule("ceph_osdmap_incremental", OSDMapIncrementalMethods);
+    Py_InitModule("ceph_crushmap", CRUSHMapMethods);
 
     PySys_SetPath(const_cast<char*>(sys_path.c_str()));
   }

--- a/src/mgr/PyModules.cc
+++ b/src/mgr/PyModules.cc
@@ -262,7 +262,14 @@ PyObject *PyModules::get_python(const std::string &what)
         }
     );
     return f.get();
-
+  } else if (what == "pg_dump") {
+    PyFormatter f;
+        cluster_state.with_pgmap(
+        [&f](const PGMap &pg_map) {
+	  pg_map.dump(&f);
+        }
+    );
+    return f.get();
   } else if (what == "df") {
     PyFormatter f;
 

--- a/src/mgr/PyModules.cc
+++ b/src/mgr/PyModules.cc
@@ -254,6 +254,14 @@ PyObject *PyModules::get_python(const std::string &what)
         }
     );
     return f.get();
+  } else if (what == "pg_status") {
+    PyFormatter f;
+    cluster_state.with_pgmap(
+        [&f](const PGMap &pg_map) {
+	  pg_map.print_summary(&f, nullptr);
+        }
+    );
+    return f.get();
 
   } else if (what == "df") {
     PyFormatter f;

--- a/src/mgr/PyModules.cc
+++ b/src/mgr/PyModules.cc
@@ -786,6 +786,29 @@ PyObject *PyModules::get_context()
   return capsule;
 }
 
+static void delete_osdmap(PyObject *object)
+{
+  OSDMap *osdmap = static_cast<OSDMap*>(PyCapsule_GetPointer(object, nullptr));
+  assert(osdmap);
+  dout(10) << __func__ << " " << osdmap << dendl;
+  delete osdmap;
+}
+
+PyObject *PyModules::get_osdmap()
+{
+  PyThreadState *tstate = PyEval_SaveThread();
+  Mutex::Locker l(lock);
+  PyEval_RestoreThread(tstate);
+
+  // Construct a capsule containing an OSDMap.
+  OSDMap *newmap = new OSDMap;
+  cluster_state.with_osdmap([&](const OSDMap& o) {
+      newmap->deepish_copy_from(o);
+    });
+  dout(10) << __func__ << " " << newmap << dendl;
+  return PyCapsule_New(newmap, nullptr, &delete_osdmap);
+}
+
 static void _list_modules(
   const std::string path,
   std::set<std::string> *modules)

--- a/src/mgr/PyModules.h
+++ b/src/mgr/PyModules.h
@@ -82,6 +82,7 @@ public:
      const std::string svc_type,
      const std::string &svc_id);
   PyObject *get_context();
+  PyObject *get_osdmap();
 
   std::map<std::string, std::string> config_cache;
 

--- a/src/mgr/PyOSDMap.cc
+++ b/src/mgr/PyOSDMap.cc
@@ -6,6 +6,7 @@
 #include "osd/OSDMap.h"
 #include "common/errno.h"
 #include "common/version.h"
+#include "include/stringify.h"
 
 #include "PyOSDMap.h"
 #include "PyFormatter.h"
@@ -22,6 +23,12 @@ static PyObject *osdmap_get_epoch(PyObject *self, PyObject *obj)
   return PyInt_FromLong(osdmap->get_epoch());
 }
 
+static PyObject *osdmap_get_crush_version(PyObject *self, PyObject *obj)
+{
+  OSDMap *osdmap = static_cast<OSDMap*>(PyCapsule_GetPointer(obj, nullptr));
+  return PyInt_FromLong(osdmap->get_crush_version());
+}
+
 static PyObject *osdmap_dump(PyObject *self, PyObject *obj)
 {
   OSDMap *osdmap = static_cast<OSDMap*>(PyCapsule_GetPointer(obj, nullptr));
@@ -35,19 +42,82 @@ static void delete_osdmap_incremental(PyObject *object)
 {
   OSDMap::Incremental *inc = static_cast<OSDMap::Incremental*>(
     PyCapsule_GetPointer(object, nullptr));
-  derr << __func__ << " " << inc << dendl;
+  dout(10) << __func__ << " " << inc << dendl;
   delete inc;
 }
 
 static PyObject *osdmap_new_incremental(PyObject *self, PyObject *obj)
 {
   OSDMap *osdmap = static_cast<OSDMap*>(PyCapsule_GetPointer(obj, nullptr));
-
-  // Construct a capsule containing an OSDMap.
   OSDMap::Incremental *inc = new OSDMap::Incremental;
   inc->fsid = osdmap->get_fsid();
   inc->epoch = osdmap->get_epoch() + 1;
+  // always include latest crush map here... this is okay since we never
+  // actually use this map in the real world (and even if we did it would
+  // be a no-op).
+  osdmap->crush->encode(inc->crush, CEPH_FEATURES_ALL);
+  dout(10) << __func__ << " " << inc << dendl;
   return PyCapsule_New(inc, nullptr, &delete_osdmap_incremental);
+}
+
+static void delete_osdmap(PyObject *object)
+{
+  OSDMap *osdmap = static_cast<OSDMap*>(PyCapsule_GetPointer(object, nullptr));
+  assert(osdmap);
+  dout(10) << __func__ << " " << osdmap << dendl;
+  delete osdmap;
+}
+
+static PyObject *osdmap_apply_incremental(PyObject *self, PyObject *args)
+{
+  PyObject *mapobj, *incobj;
+  if (!PyArg_ParseTuple(args, "OO:apply_incremental",
+			&mapobj, &incobj)) {
+    return nullptr;
+  }
+  OSDMap *osdmap = static_cast<OSDMap*>(PyCapsule_GetPointer(mapobj, nullptr));
+  OSDMap::Incremental *inc = static_cast<OSDMap::Incremental*>(
+    PyCapsule_GetPointer(incobj, nullptr));
+  if (!osdmap || !inc) {
+    return nullptr;
+  }
+
+  bufferlist bl;
+  osdmap->encode(bl, CEPH_FEATURES_ALL|CEPH_FEATURE_RESERVED);
+  OSDMap *next = new OSDMap;
+  next->decode(bl);
+  next->apply_incremental(*inc);
+  dout(10) << __func__ << " map " << osdmap << " inc " << inc
+	   << " next " << next << dendl;
+  return PyCapsule_New(next, nullptr, &delete_osdmap);
+}
+
+static PyObject *osdmap_get_crush(PyObject *self, PyObject *obj)
+{
+  OSDMap *osdmap = static_cast<OSDMap*>(PyCapsule_GetPointer(obj, nullptr));
+
+  // Construct a capsule containing a the CrushWrapper.
+  return PyCapsule_New(osdmap->crush.get(), nullptr, nullptr);
+}
+
+static PyObject *osdmap_get_pools_by_take(PyObject *self, PyObject *args)
+{
+  PyObject *mapobj;
+  int take;
+  if (!PyArg_ParseTuple(args, "Oi:get_pools_by_take",
+			&mapobj, &take)) {
+    return nullptr;
+  }
+  OSDMap *osdmap = static_cast<OSDMap*>(PyCapsule_GetPointer(mapobj, nullptr));
+  PyFormatter f;
+  f.open_array_section("pools");
+  for (auto& p : osdmap->get_pools()) {
+    if (osdmap->crush->rule_has_take(p.second.crush_rule, take)) {
+      f.dump_int("pool", p.first);
+    }
+  }
+  f.close_section();
+  return f.get();
 }
 
 static PyObject *osdmap_calc_pg_upmaps(PyObject *self, PyObject *args)
@@ -82,9 +152,15 @@ static PyObject *osdmap_calc_pg_upmaps(PyObject *self, PyObject *args)
 
 PyMethodDef OSDMapMethods[] = {
   {"get_epoch", osdmap_get_epoch, METH_O, "Get OSDMap epoch"},
+  {"get_crush_version", osdmap_get_crush_version, METH_O, "Get CRUSH version"},
   {"dump", osdmap_dump, METH_O, "Dump OSDMap::Incremental"},
   {"new_incremental", osdmap_new_incremental, METH_O,
    "Create OSDMap::Incremental"},
+  {"apply_incremental", osdmap_apply_incremental, METH_VARARGS,
+   "Apply OSDMap::Incremental and return the resulting OSDMap"},
+  {"get_crush", osdmap_get_crush, METH_O, "Get CrushWrapper"},
+  {"get_pools_by_take", osdmap_get_pools_by_take, METH_VARARGS,
+   "Get pools that have CRUSH rules that TAKE the given root"},
   {"calc_pg_upmaps", osdmap_calc_pg_upmaps, METH_VARARGS,
    "Calculate new pg-upmap values"},
   {NULL, NULL, 0, NULL}
@@ -108,18 +184,146 @@ static PyObject *osdmap_inc_dump(PyObject *self, PyObject *obj)
   return f.get();
 }
 
+static int get_int_float_map(PyObject *obj, map<int,double> *out)
+{
+  PyObject *ls = PyDict_Items(obj);
+  for (int j = 0; j < PyList_Size(ls); ++j) {
+    PyObject *pair = PyList_GET_ITEM(ls, j);
+    if (!PyTuple_Check(pair)) {
+      derr << __func__ << " item " << j << " not a tuple" << dendl;
+      return -1;
+    }
+    int k;
+    double v;
+    if (!PyArg_ParseTuple(pair, "id:pair", &k, &v)) {
+      derr << __func__ << " item " << j << " not a size 2 tuple" << dendl;
+      return -1;
+    }
+    (*out)[k] = v;
+  }
+  return 0;
+}
+
+static PyObject *osdmap_inc_set_osd_reweights(PyObject *self, PyObject *args)
+{
+  PyObject *incobj, *weightobj;
+  if (!PyArg_ParseTuple(args, "OO:set_osd_reweights",
+			&incobj, &weightobj)) {
+    return nullptr;
+  }
+  OSDMap::Incremental *inc = static_cast<OSDMap::Incremental*>(
+    PyCapsule_GetPointer(incobj, nullptr));
+  map<int,double> wm;
+  if (get_int_float_map(weightobj, &wm) < 0) {
+    return nullptr;
+  }
+
+  for (auto i : wm) {
+    inc->new_weight[i.first] = std::max(0.0, std::min(1.0, i.second)) * 0x10000;
+  }
+  Py_RETURN_NONE;
+}
+
+static PyObject *osdmap_inc_set_compat_weight_set_weights(
+  PyObject *self, PyObject *args)
+{
+  PyObject *incobj, *weightobj;
+  if (!PyArg_ParseTuple(args, "OO:set_compat_weight_set_weights",
+			&incobj, &weightobj)) {
+    return nullptr;
+  }
+  OSDMap::Incremental *inc = static_cast<OSDMap::Incremental*>(
+    PyCapsule_GetPointer(incobj, nullptr));
+  map<int,double> wm;
+  if (get_int_float_map(weightobj, &wm) < 0) {
+    return nullptr;
+  }
+
+  CrushWrapper crush;
+  assert(inc->crush.length());  // see new_incremental
+  auto p = inc->crush.begin();
+  ::decode(crush, p);
+  crush.create_choose_args(CrushWrapper::DEFAULT_CHOOSE_ARGS, 1);
+  for (auto i : wm) {
+    crush.choose_args_adjust_item_weightf(
+      g_ceph_context,
+      crush.choose_args_get(CrushWrapper::DEFAULT_CHOOSE_ARGS),
+      i.first,
+      { i.second },
+      nullptr);
+  }
+  inc->crush.clear();
+  crush.encode(inc->crush, CEPH_FEATURES_ALL);
+  Py_RETURN_NONE;
+}
+
+
+
 PyMethodDef OSDMapIncrementalMethods[] = {
   {"get_epoch", osdmap_inc_get_epoch, METH_O, "Get OSDMap::Incremental epoch"},
   {"dump", osdmap_inc_dump, METH_O, "Dump OSDMap::Incremental"},
+  {"set_osd_reweights", osdmap_inc_set_osd_reweights, METH_VARARGS,
+   "Set osd reweight values"},
+  {"set_crush_compat_weight_set_weights",
+   osdmap_inc_set_compat_weight_set_weights, METH_VARARGS,
+   "Set weight values in the pending CRUSH compat weight-set"},
   {NULL, NULL, 0, NULL}
 };
 
 
 // ----------
 
+static PyObject *crush_dump(PyObject *self, PyObject *obj)
+{
+  CrushWrapper *crush = static_cast<CrushWrapper*>(
+    PyCapsule_GetPointer(obj, nullptr));
+  PyFormatter f;
+  crush->dump(&f);
+  return f.get();
+}
 
+static PyObject *crush_find_takes(PyObject *self, PyObject *obj)
+{
+  CrushWrapper *crush = static_cast<CrushWrapper*>(
+    PyCapsule_GetPointer(obj, nullptr));
+  set<int> takes;
+  crush->find_takes(&takes);
+  PyFormatter f;
+  f.open_array_section("takes");
+  for (auto root : takes) {
+    f.dump_int("root", root);
+  }
+  f.close_section();
+  return f.get();
+}
+
+static PyObject *crush_get_take_weight_osd_map(PyObject *self, PyObject *args)
+{
+  PyObject *obj;
+  int root;
+  if (!PyArg_ParseTuple(args, "Oi:get_take_weight_osd_map",
+			&obj, &root)) {
+    return nullptr;
+  }
+  CrushWrapper *crush = static_cast<CrushWrapper*>(
+    PyCapsule_GetPointer(obj, nullptr));
+
+  map<int,float> wmap;
+  crush->get_take_weight_osd_map(root, &wmap);
+  PyFormatter f;
+  f.open_object_section("weights");
+  for (auto& p : wmap) {
+    string n = stringify(p.first);     // ick
+    f.dump_float(n.c_str(), p.second);
+  }
+  f.close_section();
+  return f.get();
+}
 
 PyMethodDef CRUSHMapMethods[] = {
-//  {"get_epoch", osdmap_get_epoch, METH_O, "Get OSDMap epoch"},
+  {"dump", crush_dump, METH_O, "Dump map"},
+  {"find_takes", crush_find_takes, METH_O, "Find distinct TAKE roots"},
+  {"get_take_weight_osd_map", crush_get_take_weight_osd_map, METH_VARARGS,
+   "Get OSD weight map for a given TAKE root node"},
   {NULL, NULL, 0, NULL}
 };

--- a/src/mgr/PyOSDMap.cc
+++ b/src/mgr/PyOSDMap.cc
@@ -1,0 +1,125 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "Mgr.h"
+
+#include "osd/OSDMap.h"
+#include "common/errno.h"
+#include "common/version.h"
+
+#include "PyOSDMap.h"
+#include "PyFormatter.h"
+#include "Gil.h"
+
+#define dout_context g_ceph_context
+#define dout_subsys ceph_subsys_mgr
+
+// ----------
+
+static PyObject *osdmap_get_epoch(PyObject *self, PyObject *obj)
+{
+  OSDMap *osdmap = static_cast<OSDMap*>(PyCapsule_GetPointer(obj, nullptr));
+  return PyInt_FromLong(osdmap->get_epoch());
+}
+
+static PyObject *osdmap_dump(PyObject *self, PyObject *obj)
+{
+  OSDMap *osdmap = static_cast<OSDMap*>(PyCapsule_GetPointer(obj, nullptr));
+  PyFormatter f;
+  osdmap->dump(&f);
+  return f.get();
+}
+
+
+static void delete_osdmap_incremental(PyObject *object)
+{
+  OSDMap::Incremental *inc = static_cast<OSDMap::Incremental*>(
+    PyCapsule_GetPointer(object, nullptr));
+  derr << __func__ << " " << inc << dendl;
+  delete inc;
+}
+
+static PyObject *osdmap_new_incremental(PyObject *self, PyObject *obj)
+{
+  OSDMap *osdmap = static_cast<OSDMap*>(PyCapsule_GetPointer(obj, nullptr));
+
+  // Construct a capsule containing an OSDMap.
+  OSDMap::Incremental *inc = new OSDMap::Incremental;
+  inc->fsid = osdmap->get_fsid();
+  inc->epoch = osdmap->get_epoch() + 1;
+  return PyCapsule_New(inc, nullptr, &delete_osdmap_incremental);
+}
+
+static PyObject *osdmap_calc_pg_upmaps(PyObject *self, PyObject *args)
+{
+  PyObject *mapobj, *incobj, *pool_list;
+  double max_deviation = 0;
+  int max_iterations = 0;
+  if (!PyArg_ParseTuple(args, "OOdiO:calc_pg_upmaps",
+			&mapobj, &incobj, &max_deviation,
+			&max_iterations, &pool_list)) {
+    return nullptr;
+  }
+
+  OSDMap *osdmap = static_cast<OSDMap*>(PyCapsule_GetPointer(mapobj, nullptr));
+  OSDMap::Incremental *inc = static_cast<OSDMap::Incremental*>(
+    PyCapsule_GetPointer(incobj, nullptr));
+
+  dout(10) << __func__ << " osdmap " << osdmap << " inc " << inc
+	   << " max_deviation " << max_deviation
+	   << " max_iterations " << max_iterations
+	   << dendl;
+  set<int64_t> pools;
+  // FIXME: unpack pool_list and translate to pools set
+  int r = osdmap->calc_pg_upmaps(g_ceph_context,
+				 max_deviation,
+				 max_iterations,
+				 pools,
+				 inc);
+  dout(10) << __func__ << " r = " << r << dendl;
+  return PyInt_FromLong(r);
+}
+
+PyMethodDef OSDMapMethods[] = {
+  {"get_epoch", osdmap_get_epoch, METH_O, "Get OSDMap epoch"},
+  {"dump", osdmap_dump, METH_O, "Dump OSDMap::Incremental"},
+  {"new_incremental", osdmap_new_incremental, METH_O,
+   "Create OSDMap::Incremental"},
+  {"calc_pg_upmaps", osdmap_calc_pg_upmaps, METH_VARARGS,
+   "Calculate new pg-upmap values"},
+  {NULL, NULL, 0, NULL}
+};
+
+// ----------
+
+static PyObject *osdmap_inc_get_epoch(PyObject *self, PyObject *obj)
+{
+  OSDMap::Incremental *inc = static_cast<OSDMap::Incremental*>(
+    PyCapsule_GetPointer(obj, nullptr));
+  return PyInt_FromLong(inc->epoch);
+}
+
+static PyObject *osdmap_inc_dump(PyObject *self, PyObject *obj)
+{
+  OSDMap::Incremental *inc = static_cast<OSDMap::Incremental*>(
+    PyCapsule_GetPointer(obj, nullptr));
+  PyFormatter f;
+  inc->dump(&f);
+  return f.get();
+}
+
+PyMethodDef OSDMapIncrementalMethods[] = {
+  {"get_epoch", osdmap_inc_get_epoch, METH_O, "Get OSDMap::Incremental epoch"},
+  {"dump", osdmap_inc_dump, METH_O, "Dump OSDMap::Incremental"},
+  {NULL, NULL, 0, NULL}
+};
+
+
+// ----------
+
+
+
+PyMethodDef CRUSHMapMethods[] = {
+//  {"get_epoch", osdmap_get_epoch, METH_O, "Get OSDMap epoch"},
+  {NULL, NULL, 0, NULL}
+};

--- a/src/mgr/PyOSDMap.h
+++ b/src/mgr/PyOSDMap.h
@@ -1,0 +1,10 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include "Python.h"
+
+extern PyMethodDef OSDMapMethods[];
+extern PyMethodDef OSDMapIncrementalMethods[];
+extern PyMethodDef CRUSHMapMethods[];

--- a/src/mgr/PyState.cc
+++ b/src/mgr/PyState.cc
@@ -348,6 +348,13 @@ get_perf_schema(PyObject *self, PyObject *args)
   return global_handle->get_perf_schema_python(handle, type_str, svc_id);
 }
 
+static PyObject *
+ceph_get_osdmap(PyObject *self, PyObject *args)
+{
+  return global_handle->get_osdmap();
+}
+
+
 PyMethodDef CephStateMethods[] = {
     {"get", ceph_state_get, METH_VARARGS,
      "Get a cluster object"},
@@ -377,6 +384,8 @@ PyMethodDef CephStateMethods[] = {
      "Get the ceph version of this process"},
     {"get_context", ceph_get_context, METH_NOARGS,
       "Get a CephContext* in a python capsule"},
+    {"get_osdmap", ceph_get_osdmap, METH_NOARGS,
+     "Get an OSDMap handle"},
     {NULL, NULL, 0, NULL}
 };
 

--- a/src/pybind/mgr/balancer/__init__.py
+++ b/src/pybind/mgr/balancer/__init__.py
@@ -1,0 +1,2 @@
+
+from module import *  # NOQA

--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -1,0 +1,109 @@
+
+"""
+Balance PG distribution across OSDs.
+"""
+
+import json
+import time
+from mgr_module import MgrModule, CommandResult
+from threading import Event
+
+# available modes: 'none', 'crush', 'crush-compat', 'upmap', 'osd_weight'
+default_mode = 'upmap'
+default_sleep_interval = 30   # seconds
+default_max_misplaced = .03   # max ratio of pgs replaced at a time
+
+class Module(MgrModule):
+    run = True
+
+    def __init__(self, *args, **kwargs):
+        super(Module, self).__init__(*args, **kwargs)
+        self.event = Event()
+
+    def handle_command(self, command):
+        return (-errno.EINVAL, '',
+                "Command not found '{0}'".format(command['prefix']))
+
+    def shutdown(self):
+        self.log.info('Stopping')
+        self.run = False
+        self.event.set()
+
+    def serve(self):
+        self.log.info('Starting')
+        while self.run:
+            mode = self.get_config('mode', default_mode)
+            sleep_interval = float(self.get_config('sleep_interval',
+                                                   default_sleep_interval))
+            max_misplaced = float(self.get_config('max_misplaced',
+                                                  default_max_misplaced))
+            self.log.info('Mode %s, sleep interval %f, max misplaced %f' %
+                          (mode, sleep_interval, max_misplaced))
+
+            info = self.get('pg_status')
+            if info.get('unknown_ratio', 0.0) + info.get('degraded_ratio', 0.0) + info.get('inactive_ratio', 0.0) > 0.0:
+                self.log.info('Some PGs are unknown, degraded, or inactive; waiting')
+            elif info.get('misplaced_ratio', 0.0) >= max_misplaced:
+                self.log.info('Too many PGs (%f > max %f) are misplaced; waiting' % (info.get('misplaced_ratio', 0.0), max_misplaced))
+            else:
+                if mode == 'upmap':
+                    self.do_upmap()
+                elif mode == 'crush':
+                    self.do_crush(compat=False)
+                elif mode == 'crush-compat':
+                    self.do_crush(compat=True)
+                elif mode == 'osd_weight':
+                    self.osd_weight()
+                elif mode == 'none':
+                    self.log.info('Idle')
+                else:
+                    self.log.info('Unrecognized mode %s' % mode)
+            self.event.wait(sleep_interval)
+
+    def do_upmap(self):
+        self.log.info('do_upmap')
+        max_iterations = self.get_config('upmap_max_iterations', 10)
+        max_deviation = self.get_config('upmap_max_deviation', .01)
+        osdmap = self.get_osdmap()
+        inc = osdmap.new_incremental()
+        osdmap.calc_pg_upmaps(inc, max_deviation, max_iterations, [])
+        incdump = inc.dump()
+        self.log.info('inc is %s' % incdump)
+
+        for pgid in incdump.get('old_pg_upmap_items', []):
+            self.log.info('ceph osd rm-pg-upmap-items %s', pgid)
+            result = CommandResult('foo')
+            self.send_command(result, 'mon', '', json.dumps({
+                'prefix': 'osd rm-pg-upmap-items',
+                'format': 'json',
+                'pgid': pgid,
+            }), 'foo')
+            r, outb, outs = result.wait()
+            if r != 0:
+                self.log.error('Error removing pg-upmap on %s' % pgid)
+                break;
+
+        for item in incdump.get('new_pg_upmap_items', []):
+            self.log.info('ceph osd pg-upmap-items %s mappings %s', item['pgid'],
+                          item['mappings'])
+            osdlist = []
+            for m in item['mappings']:
+                osdlist += [m['from'], m['to']]
+            result = CommandResult('foo')
+            self.send_command(result, 'mon', '', json.dumps({
+                'prefix': 'osd pg-upmap-items',
+                'format': 'json',
+                'pgid': item['pgid'],
+                'id': osdlist,
+            }), 'foo')
+            r, outb, outs = result.wait()
+            if r != 0:
+                self.log.error('Error setting pg-upmap on %s' % item['pgid'])
+                break;
+
+
+    def do_crush(self, compat):
+        self.log.info('do_crush compat=%b' % compat)
+
+    def do_osd_weight(self):
+        self.log.info('do_osd_weight')

--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -538,12 +538,16 @@ class Module(MgrModule):
                 break
         self.log.info('prepared %d/%d changes' % (total_did, max_iterations))
 
-    def do_crush_compat(self):
+    def do_crush_compat(self, plan):
         self.log.info('do_crush_compat')
         osdmap = self.get_osdmap()
         crush = osdmap.get_crush()
 
+        # get current compat weight-set weights
         weight_set = self.get_compat_weight_set_weights()
+
+        ms = plan.initial
+        pe = self.calc_eval(ms)
 
         # get subtree weight maps, check for overlap
         roots = crush.find_takes()

--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -136,22 +136,21 @@ class Eval:
                 # One 10% underfilled device with 5 2% overfilled devices, is arguably a better
                 # situation than one 10% overfilled with 5 2% underfilled devices
                 if adjusted > avg:
-                    '''
-                    F(x) = 2*phi(x) - 1, where phi(x) = cdf of standard normal distribution
-                    x = (adjusted - avg)/avg.
-                    Since, we're considering only over-weighted devices, x >= 0, and so phi(x) lies in [0.5, 1).
-                    To bring range of F(x) in range [0, 1), we need to make the above modification.
 
-                    In general, we need to use a function F(x), where x = (adjusted - avg)/avg
-                    1. which is bounded between 0 and 1, so that ultimately reweight_urgency will also be bounded.
-                    2. A larger value of x, should imply more urgency to reweight.
-                    3. Also, the difference between F(x) when x is large, should be minimal. 
-                    4. The value of F(x) should get close to 1 (highest urgency to reweight) with steeply.
-                    
-                    Could have used F(x) = (1 - e^(-x)). But that had slower convergence to 1, compared to the one currently in use.
+                    # F(x) = 2*phi(x) - 1, where phi(x) = cdf of standard normal distribution
+                    # x = (adjusted - avg)/avg.
+                    # Since, we're considering only over-weighted devices, x >= 0, and so phi(x) lies in [0.5, 1).
+                    # To bring range of F(x) in range [0, 1), we need to make the above modification.
 
-                    cdf of standard normal distribution: https://stackoverflow.com/a/29273201
-                    '''
+                    # In general, we need to use a function F(x), where x = (adjusted - avg)/avg
+                    # 1. which is bounded between 0 and 1, so that ultimately reweight_urgency will also be bounded.
+                    # 2. A larger value of x, should imply more urgency to reweight.
+                    # 3. Also, the difference between F(x) when x is large, should be minimal.
+                    # 4. The value of F(x) should get close to 1 (highest urgency to reweight) with steeply.
+
+                    # Could have used F(x) = (1 - e^(-x)). But that had slower convergence to 1, compared to the one currently in use.
+                    # cdf of standard normal distribution: https://en.wikipedia.org/wiki/Error_function#Cumulative_distribution_function
+
                     score += target[k] * (math.erf(((adjusted - avg)/avg) / math.sqrt(2.0)))
                     sum_weight += target[k]
                 dev += (avg - adjusted) * (avg - adjusted)

--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -182,6 +182,11 @@ class Module(MgrModule):
             "perm": "rw",
         },
         {
+            "cmd": "balancer max-iterations name=max-iterations,type=CephInt",
+            "desc": "Set max-iterations for optimization in crush-compat mode",
+            "perm": "rw",
+        },
+        {
             "cmd": "balancer on",
             "desc": "Enable automatic balancing",
             "perm": "rw",
@@ -232,6 +237,7 @@ class Module(MgrModule):
     plans = {}
     mode = ''
     key = 'pgs'
+    max_iterations = 100
 
     def __init__(self, *args, **kwargs):
         super(Module, self).__init__(*args, **kwargs)
@@ -245,6 +251,7 @@ class Module(MgrModule):
                 'active': self.active,
                 'mode': self.get_config('mode', default_mode),
                 'key': self.get_config('key', default_key),
+                'max-iterations': self.max_iterations,
             }
             return (0, json.dumps(s, indent=4), '')
         elif command['prefix'] == 'balancer mode':
@@ -252,6 +259,9 @@ class Module(MgrModule):
             return (0, '', '')
         elif command['prefix'] == 'balancer key':
             self.set_config('key', command['key'])
+            return (0, '', '')
+        elif command['prefix'] == 'balancer max-iterations':
+            self.max_iterations = max(1, command['max-iterations'])
             return (0, '', '')
         elif command['prefix'] == 'balancer on':
             if not self.active:
@@ -622,7 +632,7 @@ class Module(MgrModule):
 
         # pgs objects or bytes
         key = self.get_config('key', default_key)
-        max_iterations = 100
+        max_iterations = self.max_iterations
         no_improvement = 0
         improve_tolerance = 10
         previous_score = None

--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -16,7 +16,7 @@ default_mode = 'none'
 default_sleep_interval = 60   # seconds
 default_max_misplaced = .03   # max ratio of pgs replaced at a time
 
-TIME_FORMAT = '%Y-%m-%d %H:%M:%S %Z'
+TIME_FORMAT = '%Y-%m-%d_%H:%M:%S'
 
 
 class MappingState:
@@ -312,9 +312,11 @@ class Module(MgrModule):
                                                    default_sleep_interval))
             if self.active:
                 self.log.debug('Running')
-                plan = self.plan_create('auto-foo')
-                self.optimize(plan)
-                #self.plan_apply(plan)
+                name = 'auto_%s' % time.strftime(TIME_FORMAT, time.gmtime())
+                plan = self.plan_create(name)
+                if self.optimize(plan):
+                    self.execute(plan)
+                self.plan_rm(name)
             self.log.debug('Sleeping for %d', sleep_interval)
             self.event.wait(sleep_interval)
             self.event.clear()
@@ -536,13 +538,14 @@ class Module(MgrModule):
                           misplaced, max_misplaced)
         else:
             if plan.mode == 'upmap':
-                self.do_upmap(plan)
+                return self.do_upmap(plan)
             elif plan.mode == 'crush-compat':
-                self.do_crush_compat(plan)
+                return self.do_crush_compat(plan)
             elif plan.mode == 'none':
                 self.log.info('Idle')
             else:
                 self.log.info('Unrecognized mode %s' % plan.mode)
+        return False
 
         ##
 
@@ -555,7 +558,7 @@ class Module(MgrModule):
         pools = [str(i['pool_name']) for i in ms.osdmap_dump.get('pools',[])]
         if len(pools) == 0:
             self.log.info('no pools, nothing to do')
-            return
+            return False
         # shuffle pool list so they all get equal (in)attention
         random.shuffle(pools)
         self.log.info('pools %s' % pools)
@@ -570,6 +573,7 @@ class Module(MgrModule):
             if left <= 0:
                 break
         self.log.info('prepared %d/%d changes' % (total_did, max_iterations))
+        return True
 
     def do_crush_compat(self, plan):
         self.log.info('do_crush_compat')
@@ -597,7 +601,7 @@ class Module(MgrModule):
         if len(overlap) > 0:
             self.log.err('error: some osds belong to multiple subtrees: %s' %
                          overlap)
-            return
+            return False
 
         key = 'pgs'  # pgs objects or bytes
 
@@ -623,6 +627,7 @@ class Module(MgrModule):
                 self.log.debug('Reweight osd.%d %f -> %f', osd, weight,
                                new_weight)
                 plan.compat_ws[osd] = new_weight
+        return True
 
     def compat_weight_set_reweight(self, osd, new_weight):
         self.log.debug('ceph osd crush weight-set reweight-compat')
@@ -761,7 +766,10 @@ class Module(MgrModule):
                 'item': 'osd.%d' % osd,
                 'weight': [weight],
             }), 'foo')
-            commands.append(result)
+            r, outb, outs = result.wait()
+            if r != 0:
+                self.log.error('Error on command')
+                return
 
         # new_weight
         reweightn = {}
@@ -775,7 +783,10 @@ class Module(MgrModule):
                 'format': 'json',
                 'weights': json.dumps(reweightn),
             }), 'foo')
-            commands.append(result)
+            r, outb, outs = result.wait()
+            if r != 0:
+                self.log.error('Error on command')
+                return
 
         # upmap
         incdump = plan.inc.dump()
@@ -787,7 +798,10 @@ class Module(MgrModule):
                 'format': 'json',
                 'pgid': pgid,
             }), 'foo')
-            commands.append(result)
+            r, outb, outs = result.wait()
+            if r != 0:
+                self.log.error('Error on command')
+                return
 
         for item in incdump.get('new_pg_upmap_items', []):
             self.log.info('ceph osd pg-upmap-items %s mappings %s', item['pgid'],
@@ -802,13 +816,16 @@ class Module(MgrModule):
                 'pgid': item['pgid'],
                 'id': osdlist,
             }), 'foo')
-            commands.append(result)
-
-        # wait for commands
-        self.log.debug('commands %s' % commands)
-        for result in commands:
             r, outb, outs = result.wait()
             if r != 0:
                 self.log.error('Error on command')
                 return
+
+        # wait for commands
+        #self.log.debug('commands %s' % commands)
+        #for result in commands:
+        #    r, outb, outs = result.wait()
+        #    if r != 0:
+        #        self.log.error('Error on command')
+        #        return
         self.log.debug('done')

--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -122,14 +122,45 @@ class Eval:
         for t in ('pgs', 'objects', 'bytes'):
             avg = float(total[t]) / float(num)
             dev = 0.0
+
+            # score is a measure of how uneven the data distribution is.
+            # score lies between [0, 1), 0 means perfect distribution.
+            score = 0.0
+            sum_weight = 0.0
+
             for k, v in count[t].iteritems():
                 # adjust/normalize by weight
                 adjusted = float(v) / target[k] / float(num)
+
+                # Overweighted devices and their weights are factors to calculate reweight_urgency.
+                # One 10% underfilled device with 5 2% overfilled devices, is arguably a better
+                # situation than one 10% overfilled with 5 2% underfilled devices
+                if adjusted > avg:
+                    '''
+                    F(x) = 2*phi(x) - 1, where phi(x) = cdf of standard normal distribution
+                    x = (adjusted - avg)/avg.
+                    Since, we're considering only over-weighted devices, x >= 0, and so phi(x) lies in [0.5, 1).
+                    To bring range of F(x) in range [0, 1), we need to make the above modification.
+
+                    In general, we need to use a function F(x), where x = (adjusted - avg)/avg
+                    1. which is bounded between 0 and 1, so that ultimately reweight_urgency will also be bounded.
+                    2. A larger value of x, should imply more urgency to reweight.
+                    3. Also, the difference between F(x) when x is large, should be minimal. 
+                    4. The value of F(x) should get close to 1 (highest urgency to reweight) with steeply.
+                    
+                    Could have used F(x) = (1 - e^(-x)). But that had slower convergence to 1, compared to the one currently in use.
+
+                    cdf of standard normal distribution: https://stackoverflow.com/a/29273201
+                    '''
+                    score += target[k] * (math.erf(((adjusted - avg)/avg) / math.sqrt(2.0)))
+                    sum_weight += target[k]
                 dev += (avg - adjusted) * (avg - adjusted)
             stddev = math.sqrt(dev / float(max(num - 1, 1)))
+            score = score / max(sum_weight, 1)
             r[t] = {
                 'avg': avg,
                 'stddev': stddev,
+                'score': sum_weight,
             }
         return r
 
@@ -449,7 +480,7 @@ class Module(MgrModule):
         self.log.debug('actual_by_pool %s' % pe.actual_by_pool)
         self.log.debug('actual_by_root %s' % pe.actual_by_root)
 
-        # average and stddev
+        # average and stddev and score
         pe.stats_by_root = {
             a: pe.calc_stats(
                 b,
@@ -458,12 +489,12 @@ class Module(MgrModule):
             ) for a, b in pe.count_by_root.iteritems()
         }
             
-        # aggregate score (normalize the stddev by count)
+	# the scores are already normalized
         pe.score_by_root = {
             r: {
-                'pgs': pe.stats_by_root[r]['pgs']['stddev'] / max(1, pe.total_by_root[r]['pgs']),
-                'objects': pe.stats_by_root[r]['objects']['stddev'] / max(1, pe.total_by_root[r]['objects']),
-                'bytes': pe.stats_by_root[r]['bytes']['stddev'] / max(1, pe.total_by_root[r]['bytes']),
+                'pgs': pe.stats_by_root[r]['pgs']['score'],
+                'objects': pe.stats_by_root[r]['objects']['score'],
+                'bytes': pe.stats_by_root[r]['bytes']['score'],
             } for r in pe.total_by_root.keys()
         }
 

--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -3,27 +3,268 @@
 Balance PG distribution across OSDs.
 """
 
+import errno
 import json
+import math
 import random
 import time
 from mgr_module import MgrModule, CommandResult
 from threading import Event
 
 # available modes: 'none', 'crush', 'crush-compat', 'upmap', 'osd_weight'
-default_mode = 'upmap'
-default_sleep_interval = 30   # seconds
+default_mode = 'none'
+default_sleep_interval = 60   # seconds
 default_max_misplaced = .03   # max ratio of pgs replaced at a time
 
+TIME_FORMAT = '%Y-%m-%d %H:%M:%S %Z'
+
+
+class MappingState:
+    def __init__(self, osdmap, pg_dump, desc=''):
+        self.desc = desc
+        self.osdmap = osdmap
+        self.osdmap_dump = self.osdmap.dump()
+        self.crush = osdmap.get_crush()
+        self.crush_dump = self.crush.dump()
+        self.pg_dump = pg_dump
+        self.pg_stat = {
+            i['pgid']: i['stat_sum'] for i in pg_dump.get('pg_stats', [])
+        }
+
+
+class Plan:
+    def __init__(self, name, ms):
+        self.mode = 'unknown'
+        self.name = name
+        self.initial = ms
+
+        self.osd_weights = {}
+        self.compat_ws = {}
+        self.inc = ms.osdmap.new_incremental()
+
+    def final_state(self):
+        self.inc.set_osd_reweights(self.osd_weights)
+        self.inc.set_crush_compat_weight_set_weights(self.compat_ws)
+        return MappingState(self.initial.osdmap.apply_incremental(self.inc),
+                            self.initial.pg_dump,
+                            'plan %s final' % self.name)
+
+    def dump(self):
+        return json.dumps(self.inc.dump(), indent=4)
+
+    def show(self):
+        ls = []
+        ls.append('# starting osdmap epoch %d' % self.initial.osdmap.get_epoch())
+        ls.append('# starting crush version %d' %
+                  self.initial.osdmap.get_crush_version())
+        ls.append('# mode %s' % self.mode)
+        if len(self.compat_ws) and \
+           '-1' in self.crush_dump.get('choose_args', {}):
+            ls.append('ceph osd crush weight-set create-compat')
+        for osd, weight in self.compat_ws.iteritems():
+            ls.append('ceph osd crush weight-set reweight-compat %s %f' %
+                      (osd, weight))
+        for osd, weight in self.osd_weights.iteritems():
+            ls.append('ceph osd reweight osd.%d %f' % (osd, weight))
+        incdump = self.inc.dump()
+        for pgid in incdump.get('old_pg_upmap_items', []):
+            ls.append('ceph osd rm-pg-upmap-items %s' % pgid)
+        for item in incdump.get('new_pg_upmap_items', []):
+            osdlist = []
+            for m in item['mappings']:
+                osdlist += [m['from'], m['to']]
+            ls.append('ceph osd pg-upmap-items %s %s' %
+                      (item['pgid'], ' '.join([str(a) for a in osdlist])))
+        return '\n'.join(ls)
+
+
+class Eval:
+    pool_name = {}       # pool id -> pool name
+    pool_id = {}         # pool name -> id
+    pool_roots = {}      # pool name -> root name
+    target_by_root = {}  # root name -> target weight map
+    count_by_pool = {}
+    count_by_root = {}
+    actual_by_pool = {}  # pool -> by_* -> actual weight map
+    actual_by_root = {}  # pool -> by_* -> actual weight map
+    total_by_pool = {}   # pool -> by_* -> total
+    total_by_root = {}   # root -> by_* -> total
+    stats_by_pool = {}   # pool -> by_* -> stddev or avg -> value
+    stats_by_root = {}   # root -> by_* -> stddev or avg -> value
+
+    score_by_pool = {}
+    score_by_root = {}
+
+    score = 0.0
+
+    def __init__(self, ms):
+        self.ms = ms
+
+    def show(self):
+        r = self.ms.desc + '\n'
+        r += 'target_by_root %s\n' % self.target_by_root
+        r += 'actual_by_pool %s\n' % self.actual_by_pool
+        r += 'actual_by_root %s\n' % self.actual_by_root
+        r += 'count_by_pool %s\n' % self.count_by_pool
+        r += 'count_by_root %s\n' % self.count_by_root
+        r += 'total_by_pool %s\n' % self.total_by_pool
+        r += 'total_by_root %s\n' % self.total_by_root
+        r += 'stats_by_root %s\n' % self.stats_by_root
+        r += 'score_by_pool %s\n' % self.score_by_pool
+        r += 'score_by_root %s\n' % self.score_by_root
+        r += 'score %f (lower is better)\n' % self.score
+        return r
+
+    def calc_stats(self, count, target, total):
+        num = max(len(target), 1)
+        r = {}
+        for t in ('pgs', 'objects', 'bytes'):
+            avg = float(total[t]) / float(num)
+            dev = 0.0
+            for k, v in count[t].iteritems():
+                # adjust/normalize by weight
+                adjusted = float(v) / target[k] / float(num)
+                dev += (avg - adjusted) * (avg - adjusted)
+            stddev = math.sqrt(dev / float(max(num - 1, 1)))
+            r[t] = {
+                'avg': avg,
+                'stddev': stddev,
+            }
+        return r
+
 class Module(MgrModule):
+    COMMANDS = [
+        {
+            "cmd": "balancer status",
+            "desc": "Show balancer status",
+            "perm": "r",
+        },
+        {
+            "cmd": "balancer mode name=mode,type=CephChoices,strings=none|crush-compat|upmap",
+            "desc": "Set balancer mode",
+            "perm": "rw",
+        },
+        {
+            "cmd": "balancer on",
+            "desc": "Enable automatic balancing",
+            "perm": "rw",
+        },
+        {
+            "cmd": "balancer off",
+            "desc": "Disable automatic balancing",
+            "perm": "rw",
+        },
+        {
+            "cmd": "balancer eval name=plan,type=CephString,req=false",
+            "desc": "Evaluate data distribution for the current cluster or specific plan",
+            "perm": "r",
+        },
+        {
+            "cmd": "balancer optimize name=plan,type=CephString",
+            "desc": "Run optimizer to create a new plan",
+            "perm": "rw",
+        },
+        {
+            "cmd": "balancer show name=plan,type=CephString",
+            "desc": "Show details of an optimization plan",
+            "perm": "r",
+        },
+        {
+            "cmd": "balancer rm name=plan,type=CephString",
+            "desc": "Discard an optimization plan",
+            "perm": "rw",
+        },
+        {
+            "cmd": "balancer reset",
+            "desc": "Discard all optimization plans",
+            "perm": "rw",
+        },
+        {
+            "cmd": "balancer dump name=plan,type=CephString",
+            "desc": "Show an optimization plan",
+            "perm": "r",
+        },
+        {
+            "cmd": "balancer execute name=plan,type=CephString",
+            "desc": "Execute an optimization plan",
+            "perm": "r",
+        },
+    ]
+    active = False
     run = True
+    plans = {}
+    mode = ''
 
     def __init__(self, *args, **kwargs):
         super(Module, self).__init__(*args, **kwargs)
         self.event = Event()
 
     def handle_command(self, command):
-        return (-errno.EINVAL, '',
-                "Command not found '{0}'".format(command['prefix']))
+        self.log.warn("Handling command: '%s'" % str(command))
+        if command['prefix'] == 'balancer status':
+            s = {
+                'plans': self.plans.keys(),
+                'active': self.active,
+                'mode': self.get_config('mode', default_mode),
+            }
+            return (0, json.dumps(s, indent=4), '')
+        elif command['prefix'] == 'balancer mode':
+            self.set_config('mode', command['mode'])
+            return (0, '', '')
+        elif command['prefix'] == 'balancer on':
+            if not self.active:
+                self.set_config('active', '1')
+                self.active = True
+            self.event.set()
+            return (0, '', '')
+        elif command['prefix'] == 'balancer off':
+            if self.active:
+                self.set_config('active', '')
+                self.active = False
+            self.event.set()
+            return (0, '', '')
+        elif command['prefix'] == 'balancer eval':
+            if 'plan' in command:
+                plan = self.plans.get(command['plan'])
+                if not plan:
+                    return (-errno.ENOENT, '', 'plan %s not found' %
+                            command['plan'])
+                ms = plan.final_state()
+            else:
+                ms = MappingState(self.get_osdmap(),
+                                  self.get("pg_dump"),
+                                  'current cluster')
+            return (0, self.evaluate(ms), '')
+        elif command['prefix'] == 'balancer optimize':
+            plan = self.plan_create(command['plan'])
+            self.optimize(plan)
+            return (0, '', '')
+        elif command['prefix'] == 'balancer rm':
+            self.plan_rm(command['name'])
+            return (0, '', '')
+        elif command['prefix'] == 'balancer reset':
+            self.plans = {}
+            return (0, '', '')
+        elif command['prefix'] == 'balancer dump':
+            plan = self.plans.get(command['plan'])
+            if not plan:
+                return (-errno.ENOENT, '', 'plan %s not found' % command['plan'])
+            return (0, plan.dump(), '')
+        elif command['prefix'] == 'balancer show':
+            plan = self.plans.get(command['plan'])
+            if not plan:
+                return (-errno.ENOENT, '', 'plan %s not found' % command['plan'])
+            return (0, plan.show(), '')
+        elif command['prefix'] == 'balancer execute':
+            plan = self.plans.get(command['plan'])
+            if not plan:
+                return (-errno.ENOENT, '', 'plan %s not found' % command['plan'])
+            self.execute(plan)
+            self.plan_rm(plan)
+            return (0, '', '')
+        else:
+            return (-errno.EINVAL, '',
+                    "Command not found '{0}'".format(command['prefix']))
 
     def shutdown(self):
         self.log.info('Stopping')
@@ -33,41 +274,252 @@ class Module(MgrModule):
     def serve(self):
         self.log.info('Starting')
         while self.run:
-            mode = self.get_config('mode', default_mode)
+            self.log.debug('Waking up')
+            self.active = self.get_config('active', '') is not ''
             sleep_interval = float(self.get_config('sleep_interval',
                                                    default_sleep_interval))
-            max_misplaced = float(self.get_config('max_misplaced',
-                                                  default_max_misplaced))
-            self.log.info('Mode %s, sleep interval %f, max misplaced %f' %
-                          (mode, sleep_interval, max_misplaced))
-
-            info = self.get('pg_status')
-            if info.get('unknown_ratio', 0.0) + info.get('degraded_ratio', 0.0) + info.get('inactive_ratio', 0.0) > 0.0:
-                self.log.info('Some PGs are unknown, degraded, or inactive; waiting')
-            elif info.get('misplaced_ratio', 0.0) >= max_misplaced:
-                self.log.info('Too many PGs (%f > max %f) are misplaced; waiting' % (info.get('misplaced_ratio', 0.0), max_misplaced))
-            else:
-                if mode == 'upmap':
-                    self.do_upmap()
-                elif mode == 'crush':
-                    self.do_crush(compat=False)
-                elif mode == 'crush-compat':
-                    self.do_crush(compat=True)
-                elif mode == 'osd_weight':
-                    self.osd_weight()
-                elif mode == 'none':
-                    self.log.info('Idle')
-                else:
-                    self.log.info('Unrecognized mode %s' % mode)
+            if self.active:
+                self.log.debug('Running')
+                plan = self.plan_create('auto-foo')
+                self.optimize(plan)
+                #self.plan_apply(plan)
+            self.log.debug('Sleeping for %d', sleep_interval)
             self.event.wait(sleep_interval)
+            self.event.clear()
 
-    def do_upmap(self):
+    def plan_create(self, name):
+        plan = Plan(name, MappingState(self.get_osdmap(),
+                                       self.get("pg_dump"),
+                                       'plan %s initial' % name))
+        self.plans[name] = plan
+        return plan
+
+    def plan_rm(self, name):
+        if name in self.plans:
+            del self.plans[name]
+
+    def calc_eval(self, ms):
+        pe = Eval(ms)
+        pool_rule = {}
+        for p in ms.osdmap_dump.get('pools',[]):
+            pe.pool_name[p['pool']] = p['pool_name']
+            pe.pool_id[p['pool_name']] = p['pool']
+            pool_rule[p['pool_name']] = p['crush_rule']
+            pe.pool_roots[p['pool_name']] = []
+        pools = pe.pool_id.keys()
+        if len(pools) == 0:
+            return pe
+        self.log.debug('pool_name %s' % pe.pool_name)
+        self.log.debug('pool_id %s' % pe.pool_id)
+        self.log.debug('pools %s' % pools)
+        self.log.debug('pool_rule %s' % pool_rule)
+        
+        # get expected distributions by root
+        actual_by_root = {}
+        roots = ms.crush.find_takes()
+        for root in roots:
+            rname = ms.crush.get_item_name(root)
+            ls = ms.osdmap.get_pools_by_take(root)
+            for poolid in ls:
+                pe.pool_roots[pe.pool_name[poolid]].append(rname)
+            pe.target_by_root[rname] = ms.crush.get_take_weight_osd_map(root)
+            actual_by_root[rname] = {
+                'pgs': {},
+                'objects': {},
+                'bytes': {},
+            }
+            for osd in pe.target_by_root[rname].iterkeys():
+                actual_by_root[rname]['pgs'][osd] = 0
+                actual_by_root[rname]['objects'][osd] = 0
+                actual_by_root[rname]['bytes'][osd] = 0
+            pe.total_by_root[rname] = {
+                'pgs': 0,
+                'objects': 0,
+                'bytes': 0,
+            }
+        self.log.debug('pool_roots %s' % pe.pool_roots)
+        self.log.debug('target_by_root %s' % pe.target_by_root)
+
+        # pool and root actual
+        for pool in pools:
+            pi = [p for p in ms.osdmap_dump.get('pools',[])
+                  if p['pool_name'] == pool][0]
+            poolid = pi['pool']
+            pm = ms.osdmap.map_pool_pgs_up(poolid)
+            pgs = 0
+            objects = 0
+            bytes = 0
+            pgs_by_osd = {}
+            objects_by_osd = {}
+            bytes_by_osd = {}
+            for root in pe.pool_roots[pool]:
+                for osd in pe.target_by_root[root].iterkeys():
+                    pgs_by_osd[osd] = 0
+                    objects_by_osd[osd] = 0
+                    bytes_by_osd[osd] = 0
+            for pgid, up in pm.iteritems():
+                for osd in [int(osd) for osd in up]:
+                    pgs_by_osd[osd] += 1
+                    objects_by_osd[osd] += ms.pg_stat[pgid]['num_objects']
+                    bytes_by_osd[osd] += ms.pg_stat[pgid]['num_bytes']
+                    # pick a root to associate this pg instance with.
+                    # note that this is imprecise if the roots have
+                    # overlapping children.
+                    # FIXME: divide bytes by k for EC pools.
+                    for root in pe.pool_roots[pool]:
+                        if osd in pe.target_by_root[root]:
+                            actual_by_root[root]['pgs'][osd] += 1
+                            actual_by_root[root]['objects'][osd] += ms.pg_stat[pgid]['num_objects']
+                            actual_by_root[root]['bytes'][osd] += ms.pg_stat[pgid]['num_bytes']
+                            pgs += 1
+                            objects += ms.pg_stat[pgid]['num_objects']
+                            bytes += ms.pg_stat[pgid]['num_bytes']
+                            pe.total_by_root[root]['pgs'] += 1
+                            pe.total_by_root[root]['objects'] += ms.pg_stat[pgid]['num_objects']
+                            pe.total_by_root[root]['bytes'] += ms.pg_stat[pgid]['num_bytes']
+                            break
+            pe.count_by_pool[pool] = {
+                'pgs': {
+                    k: v
+                    for k, v in pgs_by_osd.iteritems()
+                },
+                'objects': {
+                    k: v
+                    for k, v in objects_by_osd.iteritems()
+                },
+                'bytes': {
+                    k: v
+                    for k, v in bytes_by_osd.iteritems()
+                },
+            }
+            pe.actual_by_pool[pool] = {
+                'pgs': {
+                    k: float(v) / float(max(pgs, 1))
+                    for k, v in pgs_by_osd.iteritems()
+                },
+                'objects': {
+                    k: float(v) / float(max(objects, 1))
+                    for k, v in objects_by_osd.iteritems()
+                },
+                'bytes': {
+                    k: float(v) / float(max(bytes, 1))
+                    for k, v in bytes_by_osd.iteritems()
+                },
+            }
+            pe.total_by_pool[pool] = {
+                'pgs': pgs,
+                'objects': objects,
+                'bytes': bytes,
+            }
+        for root, m in pe.total_by_root.iteritems():
+            pe.count_by_root[root] = {
+                'pgs': {
+                    k: float(v)
+                    for k, v in actual_by_root[root]['pgs'].iteritems()
+                },
+                'objects': {
+                    k: float(v)
+                    for k, v in actual_by_root[root]['objects'].iteritems()
+                },
+                'bytes': {
+                    k: float(v)
+                    for k, v in actual_by_root[root]['bytes'].iteritems()
+                },
+            }
+            pe.actual_by_root[root] = {
+                'pgs': {
+                    k: float(v) / float(max(pe.total_by_root[root]['pgs'], 1))
+                    for k, v in actual_by_root[root]['pgs'].iteritems()
+                },
+                'objects': {
+                    k: float(v) / float(max(pe.total_by_root[root]['objects'], 1))
+                    for k, v in actual_by_root[root]['objects'].iteritems()
+                },
+                'bytes': {
+                    k: float(v) / float(max(pe.total_by_root[root]['bytes'], 1))
+                    for k, v in actual_by_root[root]['bytes'].iteritems()
+                },
+            }
+        self.log.debug('actual_by_pool %s' % pe.actual_by_pool)
+        self.log.debug('actual_by_root %s' % pe.actual_by_root)
+
+        # average and stddev
+        pe.stats_by_root = {
+            a: pe.calc_stats(
+                b,
+                pe.target_by_root[a],
+                pe.total_by_root[a]
+            ) for a, b in pe.count_by_root.iteritems()
+        }
+            
+        # aggregate score (normalize the stddev by count)
+        pe.score_by_root = {
+            r: {
+                'pgs': pe.stats_by_root[r]['pgs']['stddev'] / max(1, pe.total_by_root[r]['pgs']),
+                'objects': pe.stats_by_root[r]['objects']['stddev'] / max(1, pe.total_by_root[r]['objects']),
+                'bytes': pe.stats_by_root[r]['bytes']['stddev'] / max(1, pe.total_by_root[r]['bytes']),
+            } for r in pe.total_by_root.keys()
+        }
+
+        # total score is just average of normalized stddevs
+        pe.score = 0.0
+        for r, vs in pe.score_by_root.iteritems():
+            for k, v in vs.iteritems():
+                pe.score += v
+        pe.score /= 3 * len(roots)
+        return pe
+
+    def evaluate(self, ms):
+        pe = self.calc_eval(ms)
+        return pe.show()
+    
+    def optimize(self, plan):
+        self.log.info('Optimize plan %s' % plan.name)
+        plan.mode = self.get_config('mode', default_mode)
+        max_misplaced = float(self.get_config('max_misplaced',
+                                              default_max_misplaced))
+        self.log.info('Mode %s, max misplaced %f' %
+                      (plan.mode, max_misplaced))
+
+        info = self.get('pg_status')
+        unknown = info.get('unknown_pgs_ratio', 0.0)
+        degraded = info.get('degraded_ratio', 0.0)
+        inactive = info.get('inactive_pgs_ratio', 0.0)
+        misplaced = info.get('misplaced_ratio', 0.0)
+        self.log.debug('unknown %f degraded %f inactive %f misplaced %g',
+                       unknown, degraded, inactive, misplaced)
+        if unknown > 0.0:
+            self.log.info('Some PGs (%f) are unknown; waiting', unknown)
+        elif degraded > 0.0:
+            self.log.info('Some PGs (%f) are degraded; waiting', degraded)
+        elif inactive > 0.0:
+            self.log.info('Some PGs (%f) are inactive; waiting', inactive)
+        elif misplaced >= max_misplaced:
+            self.log.info('Too many PGs (%f > %f) are misplaced; waiting',
+                          misplaced, max_misplaced)
+        else:
+            if plan.mode == 'upmap':
+                self.do_upmap(plan)
+            elif plan.mode == 'crush':
+                self.do_crush()
+            elif plan.mode == 'crush-compat':
+                self.do_crush_compat()
+            elif plan.mode == 'osd_weight':
+                self.osd_weight()
+            elif plan.mode == 'none':
+                self.log.info('Idle')
+            else:
+                self.log.info('Unrecognized mode %s' % plan.mode)
+
+        ##
+
+    def do_upmap(self, plan):
         self.log.info('do_upmap')
         max_iterations = self.get_config('upmap_max_iterations', 10)
         max_deviation = self.get_config('upmap_max_deviation', .01)
 
-        osdmap_dump = self.get('osd_map')
-        pools = [str(i['pool_name']) for i in osdmap_dump.get('pools',[])]
+        ms = plan.initial
+        pools = [str(i['pool_name']) for i in ms.osdmap_dump.get('pools',[])]
         if len(pools) == 0:
             self.log.info('no pools, nothing to do')
             return
@@ -75,21 +527,234 @@ class Module(MgrModule):
         random.shuffle(pools)
         self.log.info('pools %s' % pools)
 
-        osdmap = self.get_osdmap()
-        inc = osdmap.new_incremental()
+        inc = plan.inc
         total_did = 0
         left = max_iterations
         for pool in pools:
-            did = osdmap.calc_pg_upmaps(inc, max_deviation, left, [pool])
+            did = ms.osdmap.calc_pg_upmaps(inc, max_deviation, left, [pool])
             total_did += did
             left -= did
             if left <= 0:
                 break
         self.log.info('prepared %d/%d changes' % (total_did, max_iterations))
 
-        incdump = inc.dump()
-        self.log.debug('resulting inc is %s' % incdump)
+    def do_crush_compat(self):
+        self.log.info('do_crush_compat')
+        osdmap = self.get_osdmap()
+        crush = osdmap.get_crush()
 
+        weight_set = self.get_compat_weight_set_weights()
+
+        # get subtree weight maps, check for overlap
+        roots = crush.find_takes()
+        self.log.debug('roots %s', roots)
+        weight_maps = {}
+        visited = {}
+        overlap = {}
+        for root in roots:
+            weight_maps[root] = crush.get_take_weight_osd_map(root)
+            self.log.debug(' map for %d: %s' % (root, weight_maps[root]))
+            for osd in weight_maps[root].iterkeys():
+                if osd in visited:
+                    overlap[osd] = 1
+                visited[osd] = 1
+        if len(overlap) > 0:
+            self.log.err('error: some osds belong to multiple subtrees: %s' %
+                         overlap)
+            return
+
+        # select a cost mode: pg, pgsize, or utilization
+        # FIXME: when we add utilization support, we need to throttle back
+        # so that we don't run if *any* objects are misplaced.  with 'pgs' we
+        # can look at up mappings, which lets us look ahead a bit.
+        cost_mode = 'pg'
+
+        # go
+        random.shuffle(roots)
+        for root in roots:
+            pools = osdmap.get_pools_by_take(root)
+            self.log.info('Balancing root %s pools %s' % (root, pools))
+            wm = weight_maps[root]
+            util = self.get_util(cost_mode, pools, wm.keys())
+            self.log.info('wm %s util %s' % (wm, util))
+            if len(util) == 0:
+                self.log.info('no utilization information, stopping')
+                return
+            target = self.get_target(util)
+            self.log.info('target %s' % target)
+            if target == 0:
+                continue
+
+            queue = sorted(util, key=lambda osd: -abs(target - util[osd]))
+            self.log.info('queue %s' % queue)
+
+            for osd in queue:
+                deviation = float(util[osd]) - float(target)
+                if deviation == 0:
+                    break
+                self.log.debug('osd.%d deviation %f', osd, deviation)
+                weight = weight_set[osd]
+                calc_weight = (float(target) / float(util[osd])) * weight
+                new_weight = weight * .7 + calc_weight * .3
+                self.log.debug('Reweight osd.%d %f -> %f', osd, weight,
+                               new_weight)
+                self.compat_weight_set_reweight(osd, new_weight)
+
+    def compat_weight_set_reweight(self, osd, new_weight):
+        self.log.debug('ceph osd crush weight-set reweight-compat')
+        result = CommandResult('')
+        self.send_command(result, 'mon', '', json.dumps({
+            'prefix': 'osd crush weight-set reweight-compat',
+            'format': 'json',
+            'item': 'osd.%d' % osd,
+            'weight': [new_weight],
+        }), '')
+        r, outb, outs = result.wait()
+        if r != 0:
+            self.log.error('Error setting compat weight-set osd.%d to %f' %
+            (osd, new_weight))
+            return
+
+    def get_compat_weight_set_weights(self):
+        # enable compat weight-set
+        self.log.debug('ceph osd crush weight-set create-compat')
+        result = CommandResult('')
+        self.send_command(result, 'mon', '', json.dumps({
+            'prefix': 'osd crush weight-set create-compat',
+            'format': 'json',
+        }), '')
+        r, outb, outs = result.wait()
+        if r != 0:
+            self.log.error('Error creating compat weight-set')
+            return
+
+        result = CommandResult('')
+        self.send_command(result, 'mon', '', json.dumps({
+            'prefix': 'osd crush dump',
+            'format': 'json',
+        }), '')
+        r, outb, outs = result.wait()
+        if r != 0:
+            self.log.error('Error dumping crush map')
+            return
+        try:
+            crushmap = json.loads(outb)
+        except:
+            raise RuntimeError('unable to parse crush map')
+
+        raw = crushmap.get('choose_args',{}).get('-1', [])
+        weight_set = {}
+        for b in raw:
+            bucket = None
+            for t in crushmap['buckets']:
+                if t['id'] == b['bucket_id']:
+                    bucket = t
+                    break
+            if not bucket:
+                raise RuntimeError('could not find bucket %s' % b['bucket_id'])
+            self.log.debug('bucket items %s' % bucket['items'])
+            self.log.debug('weight set %s' % b['weight_set'][0])
+            if len(bucket['items']) != len(b['weight_set'][0]):
+                raise RuntimeError('weight-set size does not match bucket items')
+            for pos in range(len(bucket['items'])):
+                weight_set[bucket['items'][pos]['id']] = b['weight_set'][0][pos]
+
+        self.log.debug('weight_set weights %s' % weight_set)
+        return weight_set
+
+    def get_util(self, cost_mode, pools, osds):
+        if cost_mode == 'pg' or \
+           cost_mode == 'pg_bytes' or \
+           cost_mode == 'pg_objects':
+            util_map = {}
+            for osd in osds:
+                util_map[osd] = 0
+            dump = self.get('pg_dump')
+            #self.log.info('dump %s' % dump)
+            self.log.info('osds %s' % osds)
+            for pg in dump['pg_stats']:
+                inpool = False
+                for pool in pools:
+                    if pg['pgid'].startswith(str(pool) + '.'):
+                        inpool = True
+                        break
+                if not inpool:
+                    self.log.info('skipping %s' % pg['pgid'])
+                    continue
+                self.log.info('pg %s osds %s' % (pg['pgid'], pg['up']))
+                for osd in [int(a) for a in pg['up']]:
+                    if osd in osds:
+                        if cost_mode == 'pg':
+                            util_map[osd] += 1
+                        elif cost_mode == 'pg_bytes':
+                            util_map[osd] += pg['stat_sum']['num_bytes']
+                        elif cost_mode == 'pg_objects':
+                            util_map[osd] += pg['stat_sum']['num_objects']
+            return util_map
+        else:
+            raise RuntimeError('unsupported cost mode %s' % cost_mode)
+
+    def get_target(self, util_map):
+        total = 0
+        count = 0
+        for k, v in util_map.iteritems():
+            total += v;
+            count += 1
+        return total / count
+
+    def do_crush(self):
+        self.log.info('do_crush (not yet implemented)')
+
+    def do_osd_weight(self):
+        self.log.info('do_osd_weight (not yet implemented)')
+
+    def execute(self, plan):
+        self.log.info('Executing plan %s' % plan.name)
+
+        commands = []
+
+        # compat weight-set
+        if len(plan.compat_ws) and \
+           '-1' in plan.crush_dump.get('choose_args', {}):
+            self.log.debug('ceph osd crush weight-set create-compat')
+            result = CommandResult('')
+            self.send_command(result, 'mon', '', json.dumps({
+                'prefix': 'osd crush weight-set create-compat',
+                'format': 'json',
+            }), '')
+            r, outb, outs = result.wait()
+            if r != 0:
+                self.log.error('Error creating compat weight-set')
+                return
+
+        for osd, weight in plan.compat_ws.iteritems():
+            self.log.info('ceph osd crush weight-set reweight-compat osd.%d %f',
+                          osd, weight)
+            result = CommandResult('foo')
+            self.send_command(result, 'mon', '', json.dumps({
+                'prefix': 'osd crush weight-set reweight-compat',
+                'format': 'json',
+                'item': 'osd.%d' % osd,
+                'weight': [weight],
+            }), 'foo')
+            commands.append(result)
+
+        # new_weight
+        reweightn = {}
+        for osd, weight in plan.osd_weights.iteritems():
+            reweightn[int(osd)] = float(weight) / float(0x10000)
+        if len(reweightn):
+            self.log.info('ceph osd reweightn %s', reweightn)
+            result = CommandResult('foo')
+            self.send_command(result, 'mon', '', json.dumps({
+                'prefix': 'osd reweightn',
+                'format': 'json',
+                'weights': json.dumps(reweightn),
+            }), 'foo')
+            commands.append(result)
+
+        # upmap
+        incdump = plan.inc.dump()
         for pgid in incdump.get('old_pg_upmap_items', []):
             self.log.info('ceph osd rm-pg-upmap-items %s', pgid)
             result = CommandResult('foo')
@@ -98,10 +763,7 @@ class Module(MgrModule):
                 'format': 'json',
                 'pgid': pgid,
             }), 'foo')
-            r, outb, outs = result.wait()
-            if r != 0:
-                self.log.error('Error removing pg-upmap on %s' % pgid)
-                break;
+            commands.append(result)
 
         for item in incdump.get('new_pg_upmap_items', []):
             self.log.info('ceph osd pg-upmap-items %s mappings %s', item['pgid'],
@@ -116,14 +778,11 @@ class Module(MgrModule):
                 'pgid': item['pgid'],
                 'id': osdlist,
             }), 'foo')
+            commands.append(result)
+
+        # wait for commands
+        for result in commands:
             r, outb, outs = result.wait()
             if r != 0:
-                self.log.error('Error setting pg-upmap on %s' % item['pgid'])
-                break;
-
-
-    def do_crush(self, compat):
-        self.log.info('do_crush compat=%b' % compat)
-
-    def do_osd_weight(self):
-        self.log.info('do_osd_weight')
+                self.log.error('Error on command')
+                return

--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -59,7 +59,7 @@ class Plan:
                   self.initial.osdmap.get_crush_version())
         ls.append('# mode %s' % self.mode)
         if len(self.compat_ws) and \
-           '-1' in self.crush_dump.get('choose_args', {}):
+           '-1' not in self.initial.crush_dump.get('choose_args', {}):
             ls.append('ceph osd crush weight-set create-compat')
         for osd, weight in self.compat_ws.iteritems():
             ls.append('ceph osd crush weight-set reweight-compat %s %f' %
@@ -82,6 +82,7 @@ class Eval:
     pool_name = {}       # pool id -> pool name
     pool_id = {}         # pool name -> id
     pool_roots = {}      # pool name -> root name
+    root_pools = {}      # root name -> pools
     target_by_root = {}  # root name -> target weight map
     count_by_pool = {}
     count_by_root = {}
@@ -316,28 +317,33 @@ class Module(MgrModule):
         
         # get expected distributions by root
         actual_by_root = {}
-        roots = ms.crush.find_takes()
-        for root in roots:
-            rname = ms.crush.get_item_name(root)
-            ls = ms.osdmap.get_pools_by_take(root)
+        rootids = ms.crush.find_takes()
+        roots = []
+        for rootid in rootids:
+            root = ms.crush.get_item_name(rootid)
+            roots.append(root)
+            ls = ms.osdmap.get_pools_by_take(rootid)
+            pe.root_pools[root] = []
             for poolid in ls:
-                pe.pool_roots[pe.pool_name[poolid]].append(rname)
-            pe.target_by_root[rname] = ms.crush.get_take_weight_osd_map(root)
-            actual_by_root[rname] = {
+                pe.pool_roots[pe.pool_name[poolid]].append(root)
+                pe.root_pools[root].append(pe.pool_name[poolid])
+            pe.target_by_root[root] = ms.crush.get_take_weight_osd_map(rootid)
+            actual_by_root[root] = {
                 'pgs': {},
                 'objects': {},
                 'bytes': {},
             }
-            for osd in pe.target_by_root[rname].iterkeys():
-                actual_by_root[rname]['pgs'][osd] = 0
-                actual_by_root[rname]['objects'][osd] = 0
-                actual_by_root[rname]['bytes'][osd] = 0
-            pe.total_by_root[rname] = {
+            for osd in pe.target_by_root[root].iterkeys():
+                actual_by_root[root]['pgs'][osd] = 0
+                actual_by_root[root]['objects'][osd] = 0
+                actual_by_root[root]['bytes'][osd] = 0
+            pe.total_by_root[root] = {
                 'pgs': 0,
                 'objects': 0,
                 'bytes': 0,
             }
         self.log.debug('pool_roots %s' % pe.pool_roots)
+        self.log.debug('root_pools %s' % pe.root_pools)
         self.log.debug('target_by_root %s' % pe.target_by_root)
 
         # pool and root actual
@@ -500,12 +506,8 @@ class Module(MgrModule):
         else:
             if plan.mode == 'upmap':
                 self.do_upmap(plan)
-            elif plan.mode == 'crush':
-                self.do_crush()
             elif plan.mode == 'crush-compat':
-                self.do_crush_compat()
-            elif plan.mode == 'osd_weight':
-                self.osd_weight()
+                self.do_crush_compat(plan)
             elif plan.mode == 'none':
                 self.log.info('Idle')
             else:
@@ -544,21 +546,20 @@ class Module(MgrModule):
         crush = osdmap.get_crush()
 
         # get current compat weight-set weights
-        weight_set = self.get_compat_weight_set_weights()
+        old_ws = self.get_compat_weight_set_weights()
 
         ms = plan.initial
         pe = self.calc_eval(ms)
 
-        # get subtree weight maps, check for overlap
-        roots = crush.find_takes()
+        # Make sure roots don't overlap their devices.  If so, we
+        # can't proceed.
+        roots = pe.target_by_root.keys()
         self.log.debug('roots %s', roots)
-        weight_maps = {}
         visited = {}
         overlap = {}
-        for root in roots:
-            weight_maps[root] = crush.get_take_weight_osd_map(root)
-            self.log.debug(' map for %d: %s' % (root, weight_maps[root]))
-            for osd in weight_maps[root].iterkeys():
+        root_ids = {}
+        for root, wm in pe.target_by_root.iteritems():
+            for osd in wm.iterkeys():
                 if osd in visited:
                     overlap[osd] = 1
                 visited[osd] = 1
@@ -567,42 +568,30 @@ class Module(MgrModule):
                          overlap)
             return
 
-        # select a cost mode: pg, pgsize, or utilization
-        # FIXME: when we add utilization support, we need to throttle back
-        # so that we don't run if *any* objects are misplaced.  with 'pgs' we
-        # can look at up mappings, which lets us look ahead a bit.
-        cost_mode = 'pg'
+        key = 'pgs'  # pgs objects or bytes
 
         # go
         random.shuffle(roots)
         for root in roots:
-            pools = osdmap.get_pools_by_take(root)
-            self.log.info('Balancing root %s pools %s' % (root, pools))
-            wm = weight_maps[root]
-            util = self.get_util(cost_mode, pools, wm.keys())
-            self.log.info('wm %s util %s' % (wm, util))
-            if len(util) == 0:
-                self.log.info('no utilization information, stopping')
-                return
-            target = self.get_target(util)
-            self.log.info('target %s' % target)
-            if target == 0:
-                continue
-
-            queue = sorted(util, key=lambda osd: -abs(target - util[osd]))
-            self.log.info('queue %s' % queue)
-
+            pools = pe.root_pools[root]
+            self.log.info('Balancing root %s (pools %s) by %s' %
+                          (root, pools, key))
+            target = pe.target_by_root[root]
+            actual = pe.actual_by_root[root][key]
+            queue = sorted(actual.keys(),
+                           key=lambda osd: -abs(target[osd] - actual[osd]))
+            self.log.debug('queue %s' % queue)
             for osd in queue:
-                deviation = float(util[osd]) - float(target)
+                deviation = target[osd] - actual[osd]
                 if deviation == 0:
                     break
                 self.log.debug('osd.%d deviation %f', osd, deviation)
-                weight = weight_set[osd]
-                calc_weight = (float(target) / float(util[osd])) * weight
+                weight = old_ws[osd]
+                calc_weight = target[osd] / actual[osd] * weight
                 new_weight = weight * .7 + calc_weight * .3
                 self.log.debug('Reweight osd.%d %f -> %f', osd, weight,
                                new_weight)
-                self.compat_weight_set_reweight(osd, new_weight)
+                plan.compat_ws[osd] = new_weight
 
     def compat_weight_set_reweight(self, osd, new_weight):
         self.log.debug('ceph osd crush weight-set reweight-compat')
@@ -719,7 +708,7 @@ class Module(MgrModule):
 
         # compat weight-set
         if len(plan.compat_ws) and \
-           '-1' in plan.crush_dump.get('choose_args', {}):
+           '-1' not in plan.initial.crush_dump.get('choose_args', {}):
             self.log.debug('ceph osd crush weight-set create-compat')
             result = CommandResult('')
             self.send_command(result, 'mon', '', json.dumps({
@@ -785,8 +774,10 @@ class Module(MgrModule):
             commands.append(result)
 
         # wait for commands
+        self.log.debug('commands %s' % commands)
         for result in commands:
             r, outb, outs = result.wait()
             if r != 0:
                 self.log.error('Error on command')
                 return
+        self.log.debug('done')

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -802,6 +802,9 @@ class Module(MgrModule):
             'engine.autoreload.on': False
         })
 
+        osdmap = self.get_osdmap()
+        log.info("latest osdmap is %d" % osdmap.get_epoch())
+
         static_dir = os.path.join(current_dir, 'static')
         conf = {
             "/static": {

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -65,6 +65,8 @@ class OSDMap(object):
             inc._handle,
             max_deviation, max_iterations, pools)
 
+    def map_pool_pgs_up(self, poolid):
+        return ceph_osdmap.map_pool_pgs_up(self._handle, poolid)
 
 class OSDMapIncremental(object):
     def __init__(self, handle):
@@ -100,6 +102,9 @@ class CRUSHMap(object):
 
     def dump(self):
         return ceph_crushmap.dump(self._handle)
+
+    def get_item_name(self, item):
+        return ceph_crushmap.get_item_name(self._handle, item)
 
     def find_takes(self):
         return ceph_crushmap.find_takes(self._handle).get('takes',[])

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -1,5 +1,8 @@
 
 import ceph_state  #noqa
+import ceph_osdmap  #noqa
+import ceph_osdmap_incremental  #noqa
+import ceph_crushmap  #noqa
 import json
 import logging
 import threading
@@ -28,6 +31,44 @@ class CommandResult(object):
     def wait(self):
         self.ev.wait()
         return self.r, self.outb, self.outs
+
+
+class OSDMap(object):
+    def __init__(self, handle):
+        self._handle = handle
+
+    def get_epoch(self):
+        return ceph_osdmap.get_epoch(self._handle)
+
+    def dump(self):
+        return ceph_osdmap.dump(self._handle)
+
+    def new_incremental(self):
+        return OSDMapIncremental(ceph_osdmap.new_incremental(self._handle))
+
+    def calc_pg_upmaps(self, inc, max_deviation=.01, max_iterations=10, pools=[]):
+        return ceph_osdmap.calc_pg_upmaps(
+            self._handle,
+            inc._handle,
+            max_deviation, max_iterations, pools)
+
+
+class OSDMapIncremental(object):
+    def __init__(self, handle):
+        self._handle = handle
+
+    def get_epoch(self):
+        return ceph_osdmap_incremental.get_epoch(self._handle)
+
+    def dump(self):
+        return ceph_osdmap_incremental.dump(self._handle)
+
+class CRUSHMap(object):
+    def __init__(self, handle):
+        self._handle = handle
+
+#    def get_epoch(self):
+#        return ceph_crushmap.get_epoch(self._handle)
 
 
 class MgrModule(object):
@@ -275,3 +316,11 @@ class MgrModule(object):
         :return: bool
         """
         pass
+
+    def get_osdmap(self):
+        """
+        Get a handle to an OSDMap.  If epoch==0, get a handle for the latest
+        OSDMap.
+        :return: OSDMap
+        """
+        return OSDMap(ceph_state.get_osdmap())

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -236,14 +236,18 @@ class MgrModule(object):
         """
         return ceph_state.get_mgr_id()
 
-    def get_config(self, key):
+    def get_config(self, key, default=None):
         """
         Retrieve the value of a persistent configuration setting
 
         :param key: str
         :return: str
         """
-        return ceph_state.get_config(self._handle, key)
+        r = ceph_state.get_config(self._handle, key)
+        if r is None:
+            return default
+        else:
+            return r
 
     def get_config_prefix(self, key_prefix):
         """

--- a/src/tools/crushtool.cc
+++ b/src/tools/crushtool.cc
@@ -829,7 +829,7 @@ int main(int argc, const char **argv)
 
     {
       set<int> roots;
-      crush.find_roots(roots);
+      crush.find_roots(&roots);
       if (roots.size() > 1)
 	dout(1)	<< "The crush rulesets will use the root " << root << "\n"
 		<< "and ignore the others.\n"

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -516,7 +516,7 @@ $COSDMEMSTORE
 $COSDSHORT
 $extra_conf
 [mon]
-        mgr initial modules = restful status dashboard
+        mgr initial modules = restful status dashboard balancer
         mon pg warn min per osd = 3
         mon osd allow primary affinity = true
         mon reweight min pgs per osd = 4


### PR DESCRIPTION
Utilize the optimized algorithm used in Loic's python-crush to set the new weights in crush-compat mode.

Justifications for this algorithm:
1. In the existing algorithm, we change the weights of the OSDs, in such a manner that the total sum of the weights of all OSDs also changes. This makes it difficult to maintain/achieve the desired "relative weight" for a particular OSD.
2. The assigning of new_weight as  0.7 * old_weight + 0.3 * new_weight, prevents faster rate of optimization. (For e.g, if the new_weight was in fact the true optimized weight, then according to the current algorithm, it would theoretically have never attained that value)